### PR TITLE
PR(server): make the server skeleton

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -20,6 +20,8 @@ SRCS	=	src/main.c \
 			src/parsing.c \
 			src/set_server.c \
 			src/error_handling.c \
+			src/handle_client.c \
+			src/client_manager.c \
 
 OBJS	=	$(SRCS:.c=.o)
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -11,7 +11,14 @@ NAME_TESTS	=	unit_tests
 CC		=	gcc
 RM		=	rm -f
 
-SRCS	=	$(wildcard src/*.c)
+SRCS	=	src/main.c \
+            src/display_help.c \
+            src/display_infos.c \
+            src/fill_n_c_f.c \
+            src/fill_p_x_y.c \
+			src/handle_free.c \
+			src/parsing.c \
+
 OBJS	=	$(SRCS:.c=.o)
 
 TESTS	=	$(wildcard ../tests/server/*.c)

--- a/server/Makefile
+++ b/server/Makefile
@@ -18,6 +18,8 @@ SRCS	=	src/main.c \
             src/fill_p_x_y.c \
 			src/handle_free.c \
 			src/parsing.c \
+			src/set_server.c \
+			src/error_handling.c \
 
 OBJS	=	$(SRCS:.c=.o)
 

--- a/server/includes/server.h
+++ b/server/includes/server.h
@@ -7,14 +7,37 @@
 
 #ifndef SERVER_H
     #define SERVER_H
+    #define MAX_CLIENTS 100
 
     #include <stdio.h>
     #include <stdlib.h>
     #include <string.h>
     #include <unistd.h>
     #include <getopt.h>
+    #include <arpa/inet.h>
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <netinet/in.h>
+    #include <errno.h>
 
-typedef struct server_config_s {
+typedef struct client_s {
+    int fd;
+    struct sockaddr_in addr;
+    char *team_name;
+    int team_id;
+    int id;
+} client_t;
+
+typedef struct server_connection_s {
+    int fd;
+    struct sockaddr_in addr;
+    struct pollfd *fds;
+    client_t *clients;
+    int client_count;
+    int port;
+} server_connection_t;
+
+typedef struct server_args_s {
     int port;
     size_t width;
     size_t height;
@@ -23,23 +46,34 @@ typedef struct server_config_s {
     int clients_per_team;
     int frequency;
     int error_code;
-} server_config_t;
+} server_args_t;
 
-int check_args(int argc, char **argv, server_config_t *server);
-int handle_args(int argc, char **argv, server_config_t *server);
-int handle_options(int opt, char **argv, int argc, server_config_t *server);
-int parse_options(int argc, char **argv, server_config_t *server);
+typedef struct server_s {
+    server_args_t *args;
+    server_connection_t *connection;
+} server_t;
 
-void fill_port(server_config_t *server, char *optarg);
-void fill_witdh(server_config_t *server, char *optarg);
-void fill_height(server_config_t *server, char *optarg);
-void fill_name(server_config_t *server, int argc, char **argv);
-void fill_clients_nb(server_config_t *server, char *optarg);
-void fill_frequency(server_config_t *server, char *optarg);
+int check_args(int argc, char **argv, server_args_t *server);
+int handle_args(int argc, char **argv, server_t *server);
+int handle_options(int opt, char **argv, int argc, server_args_t *server);
+int parse_options(int argc, char **argv, server_args_t *server);
+
+void fill_port(server_args_t *server, char *optarg);
+void fill_witdh(server_args_t *server, char *optarg);
+void fill_height(server_args_t *server, char *optarg);
+void fill_name(server_args_t *server, int argc, char **argv);
+void fill_clients_nb(server_args_t *server, char *optarg);
+void fill_frequency(server_args_t *server, char *optarg);
 
 int display_help(void);
-void display_infos(server_config_t *server);
+void display_infos(server_args_t *server);
 
-int handle_free(server_config_t *server);
+int handle_free(server_t *server);
+void handle_error_connection(char *msg, server_connection_t *connection);
+
+void set_server(server_connection_t *connection);
+void set_bind(server_connection_t *connection);
+void set_listen(server_connection_t *connection);
+int set_server_socket(server_connection_t *connection);
 
 #endif /* SERVER_H */

--- a/server/src/client_manager.c
+++ b/server/src/client_manager.c
@@ -30,7 +30,11 @@ void handle_client_read(server_connection_t *connection, int idx)
 
     if (check_correct_read(connection, idx, bytes_read, client) == 84)
         return;
-    memcpy(client->read_buffer + client->read_index, tmp_buffer, bytes_read);
+    if (memcpy(client->read_buffer + client->read_index, tmp_buffer,
+        bytes_read) == NULL) {
+        perror("memcpy");
+        return;
+    }
     client->read_index += bytes_read;
     for (int i = 0; i < client->read_index; i++) {
         if (client->read_buffer[i] == '\n') {

--- a/server/src/client_manager.c
+++ b/server/src/client_manager.c
@@ -1,0 +1,55 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappynian
+** File description:
+** client_manager
+*/
+
+#include "../includes/server.h"
+
+void assign_client_type(client_t *client)
+{
+    if (strcmp(client->read_buffer, "GRAPHIC") == 0) {
+        client->type = CLIENT_GUI;
+        client->team_name = strdup("GRAPHIC TEAM");
+        printf("Client %d is a GUI client.\n", client->fd);
+    } else if (strcmp(client->read_buffer, "IA") == 0) {
+        client->type = CLIENT_IA;
+        client->team_name = strdup("IA TEAM");
+        printf("Client %d is an IA client.\n", client->fd);
+    } else {
+        client->type = CLIENT_UNKNOWN;
+    }
+}
+
+void handle_client_read(server_connection_t *connection, int idx)
+{
+    client_t *client = connection->clients[idx];
+    char tmp_buffer[1024] = {0};
+    ssize_t bytes_read = read(client->fd, tmp_buffer, sizeof(tmp_buffer));
+
+    if (check_correct_read(connection, idx, bytes_read, client) == 84)
+        return;
+    memcpy(client->read_buffer + client->read_index, tmp_buffer, bytes_read);
+    client->read_index += bytes_read;
+    for (int i = 0; i < client->read_index; i++) {
+        if (client->read_buffer[i] == '\n') {
+            client->read_buffer[i] = '\0';
+            assign_client_type(client);
+            client->read_index = 0;
+            break;
+        }
+    }
+}
+
+void disconnect_client(server_connection_t *connection, int client_idx)
+{
+    close(connection->clients[client_idx]->fd);
+    free(connection->clients[client_idx]);
+    for (int i = client_idx; i < connection->client_count - 1; i++)
+        connection->clients[i] = connection->clients[i + 1];
+    for (int i = client_idx; i < connection->nfds; i++)
+        connection->fds[i - 1] = connection->fds[i];
+    connection->client_count--;
+    connection->nfds--;
+}

--- a/server/src/display_infos.c
+++ b/server/src/display_infos.c
@@ -7,7 +7,7 @@
 
 #include "../includes/server.h"
 
-void display_infos(server_config_t *server)
+void display_infos(server_args_t *server)
 {
     printf("Server configuration:\n");
     printf("Port: %d\n", server->port);

--- a/server/src/error_handling.c
+++ b/server/src/error_handling.c
@@ -27,3 +27,22 @@ void handle_error_connection(char *msg, server_connection_t *connection)
     perror(msg);
     exit(EXIT_FAILURE);
 }
+
+int check_correct_read(server_connection_t *connection, int idx,
+    ssize_t bytes_read, client_t *client)
+{
+    if (bytes_read <= 0) {
+        if (bytes_read < 0)
+            perror("read");
+        else
+            printf("Client %d disconnected.\n", idx);
+        disconnect_client(connection, idx);
+        return 84;
+    }
+    if (client->read_index + bytes_read >= BUFFER_SIZE) {
+        fprintf(stderr, "Buffer overflow for client %d\n", idx);
+        disconnect_client(connection, idx);
+        return 84;
+    }
+    return 0;
+}

--- a/server/src/error_handling.c
+++ b/server/src/error_handling.c
@@ -1,0 +1,29 @@
+/*
+** EPITECH PROJECT, 2025
+** Jetpack
+** File description:
+** Error handling functions
+*/
+
+#include "../includes/server.h"
+
+void close_connection(server_connection_t *connection)
+{
+    if (connection == NULL) {
+        fprintf(stderr, "Connection is NULL.\n");
+        return;
+    }
+    if (connection->fd != -1) {
+        close(connection->fd);
+    }
+    free(connection->clients);
+    free(connection->fds);
+    free(connection);
+}
+
+void handle_error_connection(char *msg, server_connection_t *connection)
+{
+    close_connection(connection);
+    perror(msg);
+    exit(EXIT_FAILURE);
+}

--- a/server/src/fill_n_c_f.c
+++ b/server/src/fill_n_c_f.c
@@ -7,7 +7,7 @@
 
 #include "../includes/server.h"
 
-void fill_name(server_config_t *server, int argc, char **argv)
+void fill_name(server_args_t *server, int argc, char **argv)
 {
     int name_count = 0;
 
@@ -30,7 +30,7 @@ void fill_name(server_config_t *server, int argc, char **argv)
     server->team_count = name_count;
 }
 
-void fill_clients_nb(server_config_t *server, char *optarg)
+void fill_clients_nb(server_args_t *server, char *optarg)
 {
     server->clients_per_team = atoi(optarg);
     if (server->clients_per_team <= 0) {
@@ -39,7 +39,7 @@ void fill_clients_nb(server_config_t *server, char *optarg)
     }
 }
 
-void fill_frequency(server_config_t *server, char *optarg)
+void fill_frequency(server_args_t *server, char *optarg)
 {
     server->frequency = atoi(optarg);
     if (server->frequency <= 0) {

--- a/server/src/fill_p_x_y.c
+++ b/server/src/fill_p_x_y.c
@@ -7,7 +7,7 @@
 
 #include "../includes/server.h"
 
-void fill_port(server_config_t *server, char *optarg)
+void fill_port(server_args_t *server, char *optarg)
 {
     server->port = atoi(optarg);
     if (server->port <= 0 || server->port > 65535) {
@@ -16,7 +16,7 @@ void fill_port(server_config_t *server, char *optarg)
     }
 }
 
-void fill_witdh(server_config_t *server, char *optarg)
+void fill_witdh(server_args_t *server, char *optarg)
 {
     char *endptr;
     long width = strtol(optarg, &endptr, 10);
@@ -29,7 +29,7 @@ void fill_witdh(server_config_t *server, char *optarg)
     server->width = (size_t)width;
 }
 
-void fill_height(server_config_t *server, char *optarg)
+void fill_height(server_args_t *server, char *optarg)
 {
     char *endptr;
     long height = strtol(optarg, &endptr, 10);

--- a/server/src/handle_client.c
+++ b/server/src/handle_client.c
@@ -1,0 +1,74 @@
+/*
+** EPITECH PROJECT, 2025
+** Jetpack
+** File description:
+** Client connection handling
+*/
+
+#include "../includes/server.h"
+
+void accept_client(server_connection_t *connection)
+{
+    client_t *new_client = malloc(sizeof(client_t));
+
+    if (!new_client)
+        handle_error_connection("malloc", connection);
+    memset(new_client, 0, sizeof(client_t));
+    new_client->addr_len = sizeof(new_client->addr);
+    new_client->fd = accept(connection->fd,
+        (struct sockaddr *) &new_client->addr,
+        &new_client->addr_len);
+    if (new_client->fd == -1) {
+        perror("accept");
+        free(new_client);
+        return;
+    }
+    connection->clients = realloc(connection->clients,
+        (connection->client_count + 1) * sizeof(client_t *));
+    connection->clients[connection->client_count] = new_client;
+    connection->fds[connection->nfds].fd = new_client->fd;
+    connection->fds[connection->nfds].events = POLLIN;
+    connection->nfds++;
+}
+
+void check_read_client(server_connection_t *connection, int current_idx)
+{
+    int client_fd = connection->fds[current_idx].fd;
+
+    for (int i = 0; i < connection->client_count; i++) {
+        if (connection->clients[i]->fd == client_fd) {
+            handle_client_read(connection, i);
+            break;
+        }
+    }
+}
+
+void loop_clients(server_connection_t *connection, int current_idx)
+{
+    if (connection->fds[current_idx].revents & POLLIN) {
+        if (connection->fds[current_idx].fd == connection->fd &&
+            connection->client_count < MAX_CLIENTS) {
+            accept_client(connection);
+            connection->client_count++;
+        } else
+            check_read_client(connection, current_idx);
+    }
+}
+
+void handle_clients(server_t *server)
+{
+    server->connection->clients = calloc(MAX_CLIENTS, sizeof(client_t *));
+    server->connection->client_count = 0;
+    server->connection->fds = malloc(sizeof(struct pollfd) *
+        (MAX_CLIENTS + 1));
+    server->connection->nfds = 1;
+    server->connection->fds[0].fd = server->connection->fd;
+    server->connection->fds[0].events = POLLIN;
+    while (1) {
+        if (poll(server->connection->fds, server->connection->nfds, -1) == -1)
+            handle_error_connection("poll", server->connection);
+        for (int current_idx = 0;
+            current_idx < server->connection->nfds; current_idx++)
+            loop_clients(server->connection, current_idx);
+    }
+}

--- a/server/src/handle_free.c
+++ b/server/src/handle_free.c
@@ -26,10 +26,8 @@ int handle_free(server_t *server)
         handle_free_args(server->args);
     }
     if (server->connection->clients != NULL) {
-        for (int i = 0; i < server->connection->client_count; i++) {
-            close(server->connection->clients[i].fd);
-            free(server->connection->clients[i].team_name);
-        }
+        for (int i = 0; i < server->connection->client_count; i++)
+            close(server->connection->clients[i]->fd);
         free(server->connection->clients);
     }
     free(server);

--- a/server/src/handle_free.c
+++ b/server/src/handle_free.c
@@ -7,12 +7,30 @@
 
 #include "../includes/server.h"
 
-int handle_free(server_config_t *server)
+int handle_free_args(server_args_t *server)
 {
     if (server->team_names != NULL) {
         for (int i = 0; server->team_names[i]; i++)
             free(server->team_names[i]);
         free(server->team_names);
+    }
+    free(server);
+    return 0;
+}
+
+int handle_free(server_t *server)
+{
+    if (server == NULL)
+        return 0;
+    if (server->args != NULL) {
+        handle_free_args(server->args);
+    }
+    if (server->connection->clients != NULL) {
+        for (int i = 0; i < server->connection->client_count; i++) {
+            close(server->connection->clients[i].fd);
+            free(server->connection->clients[i].team_name);
+        }
+        free(server->connection->clients);
     }
     free(server);
     return 0;

--- a/server/src/main.c
+++ b/server/src/main.c
@@ -26,7 +26,5 @@ int main(int argc, char **argv)
         return handle_free(server);
     display_infos(server->args);
     set_server(server->connection);
-    while (1) {
-        sleep(1);
-    }
+    handle_clients(server);
 }

--- a/server/src/main.c
+++ b/server/src/main.c
@@ -9,23 +9,23 @@
 
 int main(int argc, char **argv)
 {
-    server_config_t *server = malloc(sizeof(server_config_t));
+    server_t *server = malloc(sizeof(server_t));
     int args_result = 0;
 
     if (server == NULL) {
         fprintf(stderr, "Memory allocation failed.\n");
         return 84;
     }
-    memset(server, 0, sizeof(server_config_t));
+    memset(server, 0, sizeof(server_t));
     args_result = handle_args(argc, argv, server);
     if (args_result == 84) {
         handle_free(server);
         return 84;
     }
-    if (args_result == 1) {
+    if (args_result == 1)
         return handle_free(server);
-    }
-    display_infos(server);
+    display_infos(server->args);
+    set_server(server->connection);
     while (1) {
         sleep(1);
     }

--- a/server/src/parsing.c
+++ b/server/src/parsing.c
@@ -7,7 +7,7 @@
 
 #include "../includes/server.h"
 
-static int process_option_p_x_y(int opt, server_config_t *server)
+static int process_option_p_x_y(int opt, server_args_t *server)
 {
     switch (opt) {
         case 'p':
@@ -25,7 +25,7 @@ static int process_option_p_x_y(int opt, server_config_t *server)
 }
 
 static int process_option_n_c_f(int opt, char **argv, int argc,
-    server_config_t *server)
+    server_args_t *server)
 {
     switch (opt) {
         case 'n':
@@ -42,7 +42,7 @@ static int process_option_n_c_f(int opt, char **argv, int argc,
     }
 }
 
-int handle_options(int opt, char **argv, int argc, server_config_t *server)
+int handle_options(int opt, char **argv, int argc, server_args_t *server)
 {
     if (process_option_p_x_y(opt, server) == 0)
         return (server->error_code == 84) ? 84 : 0;
@@ -52,7 +52,7 @@ int handle_options(int opt, char **argv, int argc, server_config_t *server)
     return 84;
 }
 
-int parse_options(int argc, char **argv, server_config_t *server)
+int parse_options(int argc, char **argv, server_args_t *server)
 {
     int opt = 0;
     char *opt_string = "p:x:y:n:c:f:";
@@ -71,7 +71,7 @@ int parse_options(int argc, char **argv, server_config_t *server)
     return 0;
 }
 
-int verify_config(server_config_t *server)
+int verify_config(server_args_t *server)
 {
     if (server->port == 0 || server->width == 0 || server->height == 0 ||
         server->team_count == 0 || server->clients_per_team == 0 ||
@@ -82,7 +82,7 @@ int verify_config(server_config_t *server)
     return 0;
 }
 
-int check_args(int argc, char **argv, server_config_t *server)
+int check_args(int argc, char **argv, server_args_t *server)
 {
     server->team_names = NULL;
     server->team_count = 0;
@@ -93,17 +93,25 @@ int check_args(int argc, char **argv, server_config_t *server)
     return 0;
 }
 
-int handle_args(int argc, char **argv, server_config_t *server)
+int handle_args(int argc, char **argv, server_t *server)
 {
+    server->connection = malloc(sizeof(server_connection_t));
+    server->args = malloc(sizeof(server_args_t));
+    if (server->args == NULL) {
+        fprintf(stderr, "Memory allocation failed for server arguments.\n");
+        return 84;
+    }
+    memset(server->args, 0, sizeof(server_args_t));
     if (argc < 2) {
         fprintf(stderr, "For the usage, check: %s -help\n", argv[0]);
         return 84;
     }
     if (argc == 2 && strcmp(argv[1], "-help") == 0)
         return display_help();
-    if (check_args(argc, argv, server) == 84) {
+    if (check_args(argc, argv, server->args) == 84) {
         fprintf(stderr, "Invalid arguments.\n");
         return 84;
     }
+    server->connection->port = server->args->port;
     return 0;
 }

--- a/server/src/set_server.c
+++ b/server/src/set_server.c
@@ -22,11 +22,8 @@ int set_server_socket(server_connection_t *connection)
 
 void set_bind(server_connection_t *connection)
 {
-    memset(&connection->addr, 0, sizeof(connection->addr));
-    if (connection == NULL) {
-        fprintf(stderr, "Server connection is NULL.\n");
-        exit(84);
-    }
+    if (memset(&connection->addr, 0, sizeof(connection->addr)) == NULL)
+        handle_error_connection("memset", connection);
     connection->addr.sin_family = AF_INET;
     connection->addr.sin_port = htons(connection->port);
     connection->addr.sin_addr.s_addr = INADDR_ANY;

--- a/server/src/set_server.c
+++ b/server/src/set_server.c
@@ -23,6 +23,10 @@ int set_server_socket(server_connection_t *connection)
 void set_bind(server_connection_t *connection)
 {
     memset(&connection->addr, 0, sizeof(connection->addr));
+    if (connection == NULL) {
+        fprintf(stderr, "Server connection is NULL.\n");
+        exit(84);
+    }
     connection->addr.sin_family = AF_INET;
     connection->addr.sin_port = htons(connection->port);
     connection->addr.sin_addr.s_addr = INADDR_ANY;

--- a/server/src/set_server.c
+++ b/server/src/set_server.c
@@ -1,0 +1,50 @@
+/*
+** EPITECH PROJECT, 2025
+** Jetpack
+** File description:
+** Server socket setup functions
+*/
+
+#include "../includes/server.h"
+
+int set_server_socket(server_connection_t *connection)
+{
+    int fd = 0;
+    int opt = 1;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
+        handle_error_connection("setsockopt", connection);
+    if (fd == -1)
+        handle_error_connection("socket", connection);
+    return fd;
+}
+
+void set_bind(server_connection_t *connection)
+{
+    memset(&connection->addr, 0, sizeof(connection->addr));
+    connection->addr.sin_family = AF_INET;
+    connection->addr.sin_port = htons(connection->port);
+    connection->addr.sin_addr.s_addr = INADDR_ANY;
+    if (bind(connection->fd, (struct sockaddr *) &connection->addr,
+        sizeof(connection->addr)) == -1)
+        handle_error_connection("bind", connection);
+}
+
+void set_listen(server_connection_t *connection)
+{
+    if (listen(connection->fd, MAX_CLIENTS) == -1)
+        handle_error_connection("listen", connection);
+}
+
+void set_server(server_connection_t *connection)
+{
+    if (connection == NULL) {
+        fprintf(stderr, "Server connection is NULL.\n");
+        exit(84);
+    }
+    connection->fd = set_server_socket(connection);
+    set_bind(connection);
+    set_listen(connection);
+    connection->clients = NULL;
+}

--- a/tests/server/test_display_infos.c
+++ b/tests/server/test_display_infos.c
@@ -11,7 +11,7 @@
 
 Test(display_infos, check_display_infos)
 {
-    server_config_t server;
+    server_args_t server;
     server.port = 8080;
     server.width = 10;
     server.height = 10;

--- a/tests/server/test_fill_n_c_f.c
+++ b/tests/server/test_fill_n_c_f.c
@@ -14,7 +14,7 @@ char *optarg;
 
 Test(fill_name, single_team_name)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_argv[] = {"./zappy_server", "-n", "Team1", NULL};
     int mock_argc = 3;
 
@@ -30,7 +30,7 @@ Test(fill_name, single_team_name)
 
 Test(fill_frequency, valid_frequency)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg = "10";
 
     optarg = mock_optarg;
@@ -41,7 +41,7 @@ Test(fill_frequency, valid_frequency)
 
 Test(fill_frequency, invalid_frequency)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg = "0";
 
     optarg = mock_optarg;
@@ -52,7 +52,7 @@ Test(fill_frequency, invalid_frequency)
 
 Test(fill_clients_nb, valid_clients_number)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg = "5";
 
     optarg = mock_optarg;
@@ -63,7 +63,7 @@ Test(fill_clients_nb, valid_clients_number)
 
 Test(fill_clients_nb, invalid_clients_number)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg = "0";
 
     optarg = mock_optarg;

--- a/tests/server/test_fill_p_x_y.c
+++ b/tests/server/test_fill_p_x_y.c
@@ -14,7 +14,7 @@ char *optarg1;
 
 Test(fill_port, valid_port)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg1 = "8080";
 
     optarg1 = mock_optarg1;
@@ -25,7 +25,7 @@ Test(fill_port, valid_port)
 
 Test(fill_port, invalid_port)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg1 = "70000";
 
     optarg1 = mock_optarg1;
@@ -35,7 +35,7 @@ Test(fill_port, invalid_port)
 
 Test(fill_width, valid_width)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg1 = "100";
 
     optarg1 = mock_optarg1;
@@ -46,7 +46,7 @@ Test(fill_width, valid_width)
 
 Test(fill_width, invalid_width)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg1 = "0";
 
     optarg1 = mock_optarg1;
@@ -56,7 +56,7 @@ Test(fill_width, invalid_width)
 
 Test(fill_height, valid_height)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg1 = "200";
 
     optarg1 = mock_optarg1;
@@ -67,7 +67,7 @@ Test(fill_height, valid_height)
 
 Test(fill_height, invalid_height)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_optarg1 = "0";
 
     optarg1 = mock_optarg1;

--- a/tests/server/test_handle_free.c
+++ b/tests/server/test_handle_free.c
@@ -11,19 +11,23 @@
 
 Test(handle_free, free_server_with_team_names)
 {
-    server_config_t *server = malloc(sizeof(server_config_t));
+    server_t *server = malloc(sizeof(server_t));
 
-    server->team_names = malloc(2 * sizeof(char *));
-    server->team_names[0] = malloc(10);
-    server->team_names[1] = NULL;
-    strcpy(server->team_names[0], "Team1");
+    server->args = malloc(sizeof(server_args_t));
+    server->connection = malloc(sizeof(server_connection_t));
+    server->args->team_names = malloc(2 * sizeof(char *));
+    server->args->team_names[0] = malloc(10);
+    server->args->team_names[1] = NULL;
+    strcpy(server->args->team_names[0], "Team1");
     cr_assert_eq(handle_free(server), 0, "handle_free should return 0");
 }
 
 Test(handle_free, free_server_without_team_names)
 {
-    server_config_t *server = malloc(sizeof(server_config_t));
+    server_t *server = malloc(sizeof(server_t));
 
-    server->team_names = NULL;
+    server->args = malloc(sizeof(server_args_t));
+    server->connection = malloc(sizeof(server_connection_t));
+    server->args->team_names = NULL;
     cr_assert_eq(handle_free(server), 0, "handle_free should return 0");
 }

--- a/tests/server/test_main.c
+++ b/tests/server/test_main.c
@@ -11,9 +11,9 @@
 
 Test(main, check_memory_allocation)
 {
-    server_config_t *server = malloc(sizeof(server_config_t));
+    server_t *server = malloc(sizeof(server_t));
 
-    cr_assert_not_null(server, "Memory allocation for server_config_t failed");
+    cr_assert_not_null(server, "Memory allocation for server_args_t failed");
     free(server);
 }
 
@@ -21,7 +21,7 @@ Test(main, check_handle_args_return_value)
 {
     char *argv[] = {"./zappy_server", "-p", "8080", "-x", "10", "-y", "10", "-n", "team1", "team2", "-c", "5", "-f", "1"};
     int argc = sizeof(argv) / sizeof(argv[0]);
-    server_config_t server;
+    server_t server;
     int result = handle_args(argc, argv, &server);
 
     cr_assert_eq(result, 0, "handle_args should return 0 for valid arguments");
@@ -31,7 +31,7 @@ Test(main, check_handle_args_invalid_port)
 {
     char *argv[] = {"./zappy_server", "-p", "invalid", "-x", "10", "-y", "10", "-n", "team1", "team2", "-c", "5", "-f", "1"};
     int argc = sizeof(argv) / sizeof(argv[0]);
-    server_config_t server;
+    server_t server;
     int result = handle_args(argc, argv, &server);
 
     cr_assert_eq(result, 84, "handle_args should return 84 for invalid port");
@@ -41,7 +41,7 @@ Test(main, check_handle_args_missing_arguments)
 {
     char *argv[] = {"./zappy_server", "-p", "8080"};
     int argc = sizeof(argv) / sizeof(argv[0]);
-    server_config_t server;
+    server_t server;
     int result = handle_args(argc, argv, &server);
 
     cr_assert_eq(result, 84, "handle_args should return 84 for missing arguments");
@@ -51,7 +51,7 @@ Test(main, check_handle_args_help_flag)
 {
     char *argv[] = {"./zappy_server", "-help"};
     int argc = sizeof(argv) / sizeof(argv[0]);
-    server_config_t server;
+    server_t server;
     int result = handle_args(argc, argv, &server);
 
     cr_assert_eq(result, 1, "handle_args should return 1 for help flag");

--- a/tests/server/test_parsing.c
+++ b/tests/server/test_parsing.c
@@ -11,7 +11,7 @@
 
 Test(handle_options, valid_option_p)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_argv[] = {"./zappy_server", "-p", "8080", NULL};
     int mock_argc = 3;
 
@@ -23,7 +23,7 @@ Test(handle_options, valid_option_p)
 
 Test(handle_options, invalid_option_p)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *mock_argv[] = {"./zappy_server", "-p", "invalid_port", NULL};
     int mock_argc = 3;
 
@@ -35,7 +35,7 @@ Test(handle_options, invalid_option_p)
 
 Test(handle_options, valid_option_c)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *argv[] = {"./zappy_server", "-p", "8080", "-x", "10", "-y", "10", "-n", "Team1", "-c", "invalid_clients", "-f", "5", NULL};
     int argc = 13;
     char *opt_string = "p:x:y:n:c:f:";
@@ -48,7 +48,7 @@ Test(handle_options, valid_option_c)
 
 Test(handle_options, invalid_option_c)
 {
-    server_config_t server = {0};
+    server_args_t server = {0};
     char *argv[] = {"./zappy_server", "-p", "70000", "-x", "10", "-y", "10", "-n", "Team1", "-c", "invalid_clients", "-f", "5", NULL};
     int argc = 13;
     char *opt_string = "p:x:y:n:c:f:";


### PR DESCRIPTION
This pull request introduces major refactoring and enhancements to the server codebase, focusing on modularization, improved client handling, and transitioning from `server_config_t` to `server_args_t` and `server_t` structures. The changes aim to streamline server operations, enhance maintainability, and improve error handling.

### Structural Refactoring:
* Replaced `server_config_t` with `server_args_t` and introduced `server_t` and `server_connection_t` structures for better separation of concerns and modularity. (`server/includes/server.h`, [server/includes/server.hL26-R97](diffhunk://#diff-c8174027fa09ad78f2c8c62bf188fc19031819c4275395bd565863a7ffd2052cL26-R97))

### Client Management Enhancements:
* Added `client_manager.c` to handle client types (`CLIENT_GUI`, `CLIENT_IA`, `CLIENT_UNKNOWN`) and manage client connections, reads, and disconnections. (`server/src/client_manager.c`, [server/src/client_manager.cR1-R55](diffhunk://#diff-4cb020299a8f8e992a6f4a4b0a37d7370be2cae4ce4330db61a0128279430bc9R1-R55))
* Implemented client connection handling functions (`accept_client`, `loop_clients`, `handle_clients`) for managing client connections and polling events. (`server/src/handle_client.c`, [server/src/handle_client.cR1-R74](diffhunk://#diff-9ae5447d79b1caa8408ccb30f579ac64b6bb5bf6ca1f78ae489d8be0c2b7522fR1-R74))

### Server Socket Setup:
* Added `set_server.c` to encapsulate server socket setup functions (`set_server_socket`, `set_bind`, `set_listen`) for initializing and managing server connections. (`server/src/set_server.c`, [server/src/set_server.cR1-R50](diffhunk://#diff-99e59add08fda1bc705f16e289069d2d8f90d165e775fe383f4b069265ac7a3bR1-R50))

### Error Handling Improvements:
* Introduced robust error handling mechanisms (`handle_error_connection`, `check_correct_read`, `close_connection`) to manage connection errors and client buffer overflows. (`server/src/error_handling.c`, [server/src/error_handling.cR1-R48](diffhunk://#diff-f6a2d0e593648b84a5567be6b002697adcf8d7c93bdca3d3b71485cfc42d4793R1-R48))

### Codebase Updates:
* Updated all references to `server_config_t` across files to use `server_args_t` or `server_t`, ensuring consistency with the new structure. (`server/src/main.c`, [[1]](diffhunk://#diff-cac1cf3fc911a7845f185faf5c4a5dc3bf0934ccbe329f8f347ffe0e5a5b61c9L12-R29); `server/src/parsing.c`, [[2]](diffhunk://#diff-6c2bdcd63bb3b3e28205fa5f75e6df2a9dafb7a781486eeab6933f385924eaf1L10-R10); `server/src/fill_p_x_y.c`, [[3]](diffhunk://#diff-2483b5dd424514e009cd006ba65e162072ba7127f0552fba74c89342f2918c56L10-R10); `tests/server/test_display_infos.c`, [[4]](diffhunk://#diff-803e9ccd76ab7adffc7580891df4f1f465c41a197f22f76de0412af403026022L14-R14)