### PR TITLE
25 netpoll wrap posix poll into zn poll

### DIFF
--- a/libzappy_net/Makefile
+++ b/libzappy_net/Makefile
@@ -36,7 +36,8 @@ SRC_C = $(SRC_DIR)/libzappy_net.c \
         $(SRC_DIR)/zappy_net_core.c \
         $(SRC_DIR)/zappy_net_socket.c \
         $(SRC_DIR)/zappy_net_server.c \
-        $(SRC_DIR)/zappy_net_client.c
+        $(SRC_DIR)/zappy_net_client.c \
+        $(SRC_DIR)/zappy_net_poll.c
 SRC_CPP =
 
 # All source files

--- a/libzappy_net/include/zappy_net.h
+++ b/libzappy_net/include/zappy_net.h
@@ -182,7 +182,7 @@
     * @return Poll result structure with bitmaps of ready sockets
     */
     zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
-                            int count, int timeout_ms);
+        int count, int timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/libzappy_net/include/zappy_net.h
+++ b/libzappy_net/include/zappy_net.h
@@ -176,13 +176,13 @@
     * for reading, writing, or have errors.
     *
     * @param sockets Array of socket handles to monitor
-    * @param events Array of events to monitor for each socket (POLLIN, POLLOUT, etc.)
+    * @param events Array of events to monitor for each socket
     * @param count Number of sockets in the array (max ZN_POLL_MAX_SOCKETS)
-    * @param timeout_ms Timeout in milliseconds (-1 for infinite, 0 for no wait)
+    * @param timeout_ms Timeout in milliseconds (-1 infinite, 0 no wait)
     * @return Poll result structure with bitmaps of ready sockets
     */
     zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
-                             int count, int timeout_ms);
+                            int count, int timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/libzappy_net/src/zappy_net_poll.c
+++ b/libzappy_net/src/zappy_net_poll.c
@@ -8,43 +8,17 @@
 #include "zappy_net_internal.h"
 #include <poll.h>
 
-static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
-                              zn_poll_result_t *result);
 static void check_poll_errors(struct pollfd *poll_fds, int index,
-                              uint64_t mask, zn_poll_result_t *result);
-
-static int validate_poll_params(zn_socket_t *sockets, short *events,
-                                int count, zn_poll_result_t *result);
-static void setup_poll_fds(zn_socket_t *sockets, short *events, int count,
-                           struct pollfd *poll_fds, zn_poll_result_t *result);
-static int execute_poll(struct pollfd *poll_fds, int count, int timeout_ms);
-
-int zn_get_fd(zn_socket_t socket)
+    uint64_t mask, zn_poll_result_t *result)
 {
-    if (!socket)
-        return -1;
-    return socket->fd;
-}
-
-zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
-                        int count, int timeout_ms)
-{
-    zn_poll_result_t result = {0, 0, 0, 0};
-    struct pollfd poll_fds[ZN_POLL_MAX_SOCKETS];
-    int ready;
-
-    if (validate_poll_params(sockets, events, count, &result) < 0)
-        return result;
-    setup_poll_fds(sockets, events, count, poll_fds, &result);
-    ready = execute_poll(poll_fds, count, timeout_ms);
-    if (ready <= 0)
-        return result;
-    build_poll_bitmaps(poll_fds, count, &result);
-    return result;
+    if (poll_fds[index].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+        result->error |= mask;
+        result->ready_count++;
+    }
 }
 
 static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
-                              zn_poll_result_t *result)
+    zn_poll_result_t *result)
 {
     uint64_t mask;
 
@@ -62,17 +36,8 @@ static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
     }
 }
 
-static void check_poll_errors(struct pollfd *poll_fds, int index,
-                              uint64_t mask, zn_poll_result_t *result)
-{
-    if (poll_fds[index].revents & (POLLERR | POLLHUP | POLLNVAL)) {
-        result->error |= mask;
-        result->ready_count++;
-    }
-}
-
 static int validate_poll_params(zn_socket_t *sockets, short *events,
-                                int count, zn_poll_result_t *result)
+    int count, zn_poll_result_t *result)
 {
     if (!sockets || !events || count <= 0 || count > ZN_POLL_MAX_SOCKETS) {
         result->error = ~0ULL;
@@ -82,16 +47,22 @@ static int validate_poll_params(zn_socket_t *sockets, short *events,
 }
 
 static void setup_poll_fds(zn_socket_t *sockets, short *events, int count,
-                           struct pollfd *poll_fds, zn_poll_result_t *result)
+    struct pollfd *poll_fds)
+{
+    for (int i = 0; i < count; i++) {
+        poll_fds[i].fd = sockets[i]->fd;
+        poll_fds[i].events = events[i];
+        poll_fds[i].revents = 0;
+    }
+}
+
+static void handle_invalid_sockets(zn_socket_t *sockets, int count,
+    zn_poll_result_t *result)
 {
     for (int i = 0; i < count; i++) {
         if (!sockets[i] || sockets[i]->fd < 0) {
             result->error |= (1ULL << i);
-            continue;
         }
-        poll_fds[i].fd = sockets[i]->fd;
-        poll_fds[i].events = events[i];
-        poll_fds[i].revents = 0;
     }
 }
 
@@ -103,4 +74,29 @@ static int execute_poll(struct pollfd *poll_fds, int count, int timeout_ms)
         ready = poll(poll_fds, count, timeout_ms);
     } while (ready == -1 && errno == EINTR);
     return ready;
+}
+
+int zn_get_fd(zn_socket_t socket)
+{
+    if (!socket)
+        return -1;
+    return socket->fd;
+}
+
+zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
+    int count, int timeout_ms)
+{
+    zn_poll_result_t result = {0, 0, 0, 0};
+    struct pollfd poll_fds[ZN_POLL_MAX_SOCKETS];
+    int ready;
+
+    if (validate_poll_params(sockets, events, count, &result) < 0)
+        return result;
+    handle_invalid_sockets(sockets, count, &result);
+    setup_poll_fds(sockets, events, count, poll_fds);
+    ready = execute_poll(poll_fds, count, timeout_ms);
+    if (ready <= 0)
+        return result;
+    build_poll_bitmaps(poll_fds, count, &result);
+    return result;
 }

--- a/libzappy_net/src/zappy_net_poll.c
+++ b/libzappy_net/src/zappy_net_poll.c
@@ -1,0 +1,79 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappy
+** File description:
+** Zappy Network Library - Poll Operations
+*/
+
+#include "zappy_net_internal.h"
+#include <poll.h>
+
+static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
+                               zn_poll_result_t *result);
+static void check_poll_errors(struct pollfd *poll_fds, int index,
+                              uint64_t mask, zn_poll_result_t *result);
+
+int zn_get_fd(zn_socket_t socket)
+{
+    if (!socket)
+        return -1;
+    return socket->fd;
+}
+
+zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
+                         int count, int timeout_ms)
+{
+    zn_poll_result_t result = {0, 0, 0, 0};
+    struct pollfd poll_fds[ZN_POLL_MAX_SOCKETS];
+    int ready;
+
+    if (!sockets || !events || count <= 0 || count > ZN_POLL_MAX_SOCKETS) {
+        result.error = ~0ULL;
+        return result;
+    }
+    for (int i = 0; i < count; i++) {
+        if (!sockets[i] || sockets[i]->fd < 0) {
+            result.error |= (1ULL << i);
+            continue;
+        }
+        poll_fds[i].fd = sockets[i]->fd;
+        poll_fds[i].events = events[i];
+        poll_fds[i].revents = 0;
+    }
+    do {
+        ready = poll(poll_fds, count, timeout_ms);
+    } while (ready == -1 && errno == EINTR);
+
+    if (ready <= 0)
+        return result;
+    build_poll_bitmaps(poll_fds, count, &result);
+    return result;
+}
+
+static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
+                               zn_poll_result_t *result)
+{
+    uint64_t mask;
+
+    for (int i = 0; i < count; i++) {
+        mask = 1ULL << i;
+        if (poll_fds[i].revents & (POLLIN | POLLPRI)) {
+            result->readable |= mask;
+            result->ready_count++;
+        }
+        if (poll_fds[i].revents & POLLOUT) {
+            result->writable |= mask;
+            result->ready_count++;
+        }
+        check_poll_errors(poll_fds, i, mask, result);
+    }
+}
+
+static void check_poll_errors(struct pollfd *poll_fds, int index,
+                              uint64_t mask, zn_poll_result_t *result)
+{
+    if (poll_fds[index].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+        result->error |= mask;
+        result->ready_count++;
+    }
+}

--- a/libzappy_net/src/zappy_net_poll.c
+++ b/libzappy_net/src/zappy_net_poll.c
@@ -9,9 +9,15 @@
 #include <poll.h>
 
 static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
-                               zn_poll_result_t *result);
+                              zn_poll_result_t *result);
 static void check_poll_errors(struct pollfd *poll_fds, int index,
                               uint64_t mask, zn_poll_result_t *result);
+
+static int validate_poll_params(zn_socket_t *sockets, short *events,
+                                int count, zn_poll_result_t *result);
+static void setup_poll_fds(zn_socket_t *sockets, short *events, int count,
+                           struct pollfd *poll_fds, zn_poll_result_t *result);
+static int execute_poll(struct pollfd *poll_fds, int count, int timeout_ms);
 
 int zn_get_fd(zn_socket_t socket)
 {
@@ -21,29 +27,16 @@ int zn_get_fd(zn_socket_t socket)
 }
 
 zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
-                         int count, int timeout_ms)
+                        int count, int timeout_ms)
 {
     zn_poll_result_t result = {0, 0, 0, 0};
     struct pollfd poll_fds[ZN_POLL_MAX_SOCKETS];
     int ready;
 
-    if (!sockets || !events || count <= 0 || count > ZN_POLL_MAX_SOCKETS) {
-        result.error = ~0ULL;
+    if (validate_poll_params(sockets, events, count, &result) < 0)
         return result;
-    }
-    for (int i = 0; i < count; i++) {
-        if (!sockets[i] || sockets[i]->fd < 0) {
-            result.error |= (1ULL << i);
-            continue;
-        }
-        poll_fds[i].fd = sockets[i]->fd;
-        poll_fds[i].events = events[i];
-        poll_fds[i].revents = 0;
-    }
-    do {
-        ready = poll(poll_fds, count, timeout_ms);
-    } while (ready == -1 && errno == EINTR);
-
+    setup_poll_fds(sockets, events, count, poll_fds, &result);
+    ready = execute_poll(poll_fds, count, timeout_ms);
     if (ready <= 0)
         return result;
     build_poll_bitmaps(poll_fds, count, &result);
@@ -51,7 +44,7 @@ zn_poll_result_t zn_poll(zn_socket_t *sockets, short *events,
 }
 
 static void build_poll_bitmaps(struct pollfd *poll_fds, int count,
-                               zn_poll_result_t *result)
+                              zn_poll_result_t *result)
 {
     uint64_t mask;
 
@@ -76,4 +69,38 @@ static void check_poll_errors(struct pollfd *poll_fds, int index,
         result->error |= mask;
         result->ready_count++;
     }
+}
+
+static int validate_poll_params(zn_socket_t *sockets, short *events,
+                                int count, zn_poll_result_t *result)
+{
+    if (!sockets || !events || count <= 0 || count > ZN_POLL_MAX_SOCKETS) {
+        result->error = ~0ULL;
+        return -1;
+    }
+    return 0;
+}
+
+static void setup_poll_fds(zn_socket_t *sockets, short *events, int count,
+                           struct pollfd *poll_fds, zn_poll_result_t *result)
+{
+    for (int i = 0; i < count; i++) {
+        if (!sockets[i] || sockets[i]->fd < 0) {
+            result->error |= (1ULL << i);
+            continue;
+        }
+        poll_fds[i].fd = sockets[i]->fd;
+        poll_fds[i].events = events[i];
+        poll_fds[i].revents = 0;
+    }
+}
+
+static int execute_poll(struct pollfd *poll_fds, int count, int timeout_ms)
+{
+    int ready;
+
+    do {
+        ready = poll(poll_fds, count, timeout_ms);
+    } while (ready == -1 && errno == EINTR);
+    return ready;
 }

--- a/libzappy_net/src/zappy_net_server.c
+++ b/libzappy_net/src/zappy_net_server.c
@@ -53,7 +53,7 @@ zn_socket_t zn_server_listen(int port)
 {
     zn_socket_t sock;
 
-    if (port <= 0 || port > 65535) {
+    if (port < 0 || port > 65535) {
         return NULL;
     }
     if (create_and_init_server_socket(&sock) < 0) {

--- a/tests/zappy_net_lib/Makefile
+++ b/tests/zappy_net_lib/Makefile
@@ -26,6 +26,7 @@ SRC_FILES = test_socket_creation.c \
             test_loopback.c \
             test_socket_close.c \
             test_edge_cases.c \
+            test_pollbusy.c \
             test_helpers.c
 
 # Object files

--- a/tests/zappy_net_lib/test_pollbusy.c
+++ b/tests/zappy_net_lib/test_pollbusy.c
@@ -1,0 +1,122 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappy
+** File description:
+** Performance test for zn_poll - CPU usage benchmark
+*/
+
+#include <criterion/criterion.h>
+#include "../../libzappy_net/include/zappy_net.h"
+#include <time.h>
+#include <sys/resource.h>
+#include <poll.h>
+
+static double get_cpu_usage(struct rusage *start, struct rusage *end,
+                           double elapsed_time)
+{
+    double user_time = (end->ru_utime.tv_sec - start->ru_utime.tv_sec) +
+                      (end->ru_utime.tv_usec - start->ru_utime.tv_usec) / 1000000.0;
+    double sys_time = (end->ru_stime.tv_sec - start->ru_stime.tv_sec) +
+                     (end->ru_stime.tv_usec - start->ru_stime.tv_usec) / 1000000.0;
+
+    return ((user_time + sys_time) / elapsed_time) * 100.0;
+}
+
+Test(zn_poll_performance, cpu_usage_idle, .timeout = 10)
+{
+    zn_socket_t server = zn_server_listen(0);
+    cr_assert_not_null(server, "Failed to create server socket");
+
+    zn_socket_t sockets[5] = {server, server, server, server, server};
+    short events[5] = {POLLIN, POLLIN, POLLIN, POLLIN, POLLIN};
+
+    struct rusage usage_start, usage_end;
+    getrusage(RUSAGE_SELF, &usage_start);
+
+    time_t start_time = time(NULL);
+    int iterations = 0;
+
+    while (time(NULL) - start_time < 5) {
+        zn_poll_result_t result = zn_poll(sockets, events, 5, 100);
+        iterations++;
+
+        cr_assert_eq(result.ready_count, 0,
+                    "Expected no ready sockets in idle test");
+        cr_assert_eq(result.readable, 0,
+                    "Expected no readable sockets in idle test");
+        cr_assert_eq(result.writable, 0,
+                    "Expected no writable sockets in idle test");
+        cr_assert_eq(result.error, 0,
+                    "Expected no error sockets in idle test");
+    }
+
+    getrusage(RUSAGE_SELF, &usage_end);
+    double elapsed_time = 5.0;
+    double cpu_usage = get_cpu_usage(&usage_start, &usage_end, elapsed_time);
+
+    cr_log_info("CPU usage over 5s: %.2f%% (%d iterations)",
+           cpu_usage, iterations);
+    cr_log_info("Average time per poll: %.2f ms",
+           (elapsed_time * 1000.0) / iterations);
+
+    cr_assert_lt(cpu_usage, 3.0,
+               "CPU usage too high: %.2f%% (expected < 3%%)", cpu_usage);
+
+    zn_close(server);
+}
+
+Test(zn_poll_functionality, bitmap_return)
+{
+    zn_socket_t server = zn_server_listen(0);
+    cr_assert_not_null(server, "Failed to create server socket");
+
+    zn_socket_t sockets[1] = {server};
+    short events[1] = {POLLIN};
+
+    zn_poll_result_t result = zn_poll(sockets, events, 1, 0);
+
+    cr_assert_eq(result.readable, 0, "Server should not be ready for reading");
+    cr_assert_eq(result.ready_count, 0, "No sockets should be ready");
+
+    zn_close(server);
+}
+
+Test(zn_poll_edge_cases, null_parameters)
+{
+    zn_poll_result_t result;
+    zn_socket_t socket = zn_server_listen(0);
+    short events = POLLIN;
+
+    result = zn_poll(NULL, &events, 1, 0);
+    cr_assert_eq(result.error, ~0ULL, "Expected error for NULL sockets");
+
+    result = zn_poll(&socket, NULL, 1, 0);
+    cr_assert_eq(result.error, ~0ULL, "Expected error for NULL events");
+
+    result = zn_poll(&socket, &events, 0, 0);
+    cr_assert_eq(result.error, ~0ULL, "Expected error for zero count");
+
+    result = zn_poll(&socket, &events, ZN_POLL_MAX_SOCKETS + 1, 0);
+    cr_assert_eq(result.error, ~0ULL, "Expected error for too many sockets");
+
+    zn_close(socket);
+}
+
+Test(zn_poll_timeout, behavior, .timeout = 5)
+{
+    zn_socket_t server = zn_server_listen(0);
+    cr_assert_not_null(server, "Failed to create server");
+
+    short events = POLLIN;
+    time_t start_time = time(NULL);
+
+    zn_poll_result_t result = zn_poll(&server, &events, 1, 1000);
+
+    time_t elapsed = time(NULL) - start_time;
+
+    cr_assert_geq(elapsed, 1, "Timeout should take at least 1 second");
+    cr_assert_leq(elapsed, 2, "Timeout should not take more than 2 seconds");
+    cr_assert_eq(result.ready_count, 0, "No sockets should be ready");
+
+    zn_close(server);
+}

--- a/tests/zappy_net_lib/test_server_socket.c
+++ b/tests/zappy_net_lib/test_server_socket.c
@@ -10,11 +10,12 @@
 #include <sys/socket.h>
 #include "../../libzappy_net/include/zappy_net.h"
 
-Test(server_socket, test_server_listen_invalid_port_zero)
+Test(server_socket, test_server_listen_port_zero_auto_assign)
 {
     zn_socket_t sock = zn_server_listen(0);
 
-    cr_assert_null(sock, "Server listen with port 0 should fail");
+    cr_assert_not_null(sock, "Server listen with port 0 should succeed (auto-assign)");
+    zn_close(sock);
 }
 
 Test(server_socket, test_server_listen_invalid_port_negative)


### PR DESCRIPTION
This pull request introduces significant enhancements to the `libzappy_net` networking library, focusing on adding polling functionality, improving socket handling, and refining edge case handling. It also includes updates to the test suite to validate these changes. The most important changes are grouped below by theme.

### Polling Functionality
* Added a new source file `zappy_net_poll.c` implementing the `zn_poll` function for polling multiple sockets with timeout. It includes features like bitmaps for readable, writable, and error states, and validation for polling parameters.
* Updated `libzappy_net/include/zappy_net.h` to include the `poll.h` header, define the `ZN_POLL_MAX_SOCKETS` constant, and introduce the `zn_poll_result_t` structure for polling results. [[1]](diffhunk://#diff-6cc188dde7dd354b8e590c4f7f4cb7931407c74701174b84a395e55f670f4866R20) [[2]](diffhunk://#diff-6cc188dde7dd354b8e590c4f7f4cb7931407c74701174b84a395e55f670f4866R140-R186)

### Socket Enhancements
* Modified `zn_server_listen` to allow port 0 for auto-assigning a free port, improving flexibility in server socket creation. [[1]](diffhunk://#diff-6cc188dde7dd354b8e590c4f7f4cb7931407c74701174b84a395e55f670f4866L107-R109) [[2]](diffhunk://#diff-b2596f462b030ce44c9fb73937416cc1bc637fd8774fd535a5639e27b256b6ceL56-R56)
* Added the `zn_get_fd` function to retrieve the file descriptor from a socket handle, enabling advanced socket operations. [[1]](diffhunk://#diff-6cc188dde7dd354b8e590c4f7f4cb7931407c74701174b84a395e55f670f4866R140-R186) [[2]](diffhunk://#diff-ffa1fecfc9a4eb22f9917c65648d9975b56099d42f87edd2d000ce7740efa425R1-R102)

### Testing Improvements
* Added a new test file `test_pollbusy.c` to validate `zn_poll` functionality, including performance benchmarks, edge case handling, and timeout behavior.
* Updated existing tests in `test_server_socket.c` to validate the new behavior of `zn_server_listen` when using port 0 for auto-assignment.

### Build System Updates
* Updated `Makefile` files to include the new source file `zappy_net_poll.c` and test file `test_pollbusy.c` in the build process. [[1]](diffhunk://#diff-a422b69bf913ce9d78cee9caa237e903d31f4480cdc49554f16605004404d5d3L39-R40) [[2]](diffhunk://#diff-ce33c3c081ed2686d1b2a3711d19fe8e7f8e2be67c89274749d41df99d813b89R29)