### PR TITLE
refactor(EntityManager): optimize stone placement logic

### DIFF
--- a/gui/Core/EntityManager.cpp
+++ b/gui/Core/EntityManager.cpp
@@ -77,16 +77,16 @@ void EntityManager::createStones(int x, int y, int q0, int q1, int q2, int q3,
   for (size_t i = 1; i < quantities.size(); ++i)
   if (quantities[i] > 0)
     ++numStones;
-  if (quantities[0] > 0) {
-  entity_.push_back(std::make_shared<Stone>(
-    -1, position, qScale[0], stoneTextures[0], qB3D[0], stoneNames[0]));
-  entity_.back()->createNode(smgr_, driver_);
+  for (int i = 0; i < quantities[0]; ++i) {
+    entity_.push_back(std::make_shared<Stone>(
+      -1, position, qScale[0], stoneTextures[0], qB3D[0], stoneNames[0]));
+    entity_.back()->createNode(smgr_, driver_);
   }
   if (numStones == 0)
   return;
 
   float radius = 6.0f;
-  float angleStep = 2.0f * 3.14159265f / numStones;
+  float angleStep = 2.0f * M_PI / numStones;
   int placed = 0;
   for (size_t i = 1; i < quantities.size(); ++i) {
   if (quantities[i] > 0) {


### PR DESCRIPTION
This pull request refactors the `createStones` method in `gui/Core/EntityManager.cpp` to improve the arrangement of stones and enhance scalability. The changes replace the previous grid-based layout with a circular arrangement and adjust scaling factors for better visual consistency.

### Refactoring of stone arrangement:

* Replaced the grid-based stone placement logic with a circular arrangement. Stones are now positioned based on a calculated radius and angle, ensuring a more visually appealing layout.
* Introduced a `radius` variable and `angleStep` calculation to determine the circular positions of stones. This replaces the previous grid-based row and column calculations.

### Scaling adjustments:

* Updated the scaling factors in the `qScale` vector to increase the size of stones, improving their visibility. The default scale was changed from `(0.4f, 0.4f, 0.4f)` to `(0.8f, 0.8f, 0.8f)`, and the resized scale was changed from `(0.005f, 0.005f, 0.005f)` to `(0.009f, 0.009f, 0.009f)`.…es method