### PR TITLE
PR(GUI): death of a player

### DIFF
--- a/gui/Core/EntityManager.cpp
+++ b/gui/Core/EntityManager.cpp
@@ -37,68 +37,68 @@ void EntityManager::createPlayers(int id, int x, int y, Direction direction,
 }
 
 void EntityManager::createStones(int x, int y, int q0, int q1, int q2, int q3,
-         int q4, int q5, int q6) {
+                                 int q4, int q5, int q6) {
   std::vector<std::vector<irr::io::path>> stoneTextures = {
-  {mediaPath_ + "stone_texture/food_redbull.png",
-   mediaPath_ + "stone_texture/food_redbull.png"},
-  {mediaPath_ + "stone_texture/stone_red.png"},
-  {mediaPath_ + "stone_texture/stone_orange.png"},
-  {mediaPath_ + "stone_texture/stone_yellow.png"},
-  {mediaPath_ + "stone_texture/stone_green.png"},
-  {mediaPath_ + "stone_texture/stone_blue.png"},
-  {mediaPath_ + "stone_texture/stone_purple.png"}};
+      {mediaPath_ + "stone_texture/food_redbull.png",
+       mediaPath_ + "stone_texture/food_redbull.png"},
+      {mediaPath_ + "stone_texture/stone_red.png"},
+      {mediaPath_ + "stone_texture/stone_orange.png"},
+      {mediaPath_ + "stone_texture/stone_yellow.png"},
+      {mediaPath_ + "stone_texture/stone_green.png"},
+      {mediaPath_ + "stone_texture/stone_blue.png"},
+      {mediaPath_ + "stone_texture/stone_purple.png"}};
   std::vector<std::string> stoneNames = {"food",    "linemate", "deraumere",
-           "sibur",   "mendiane", "phiras",
-           "thystame"};
+                                         "sibur",   "mendiane", "phiras",
+                                         "thystame"};
   std::vector<irr::io::path> qB3D(7, mediaPath_ + "ruby.b3d");
   qB3D[0] = mediaPath_ + "RedBull.b3d";
   std::vector<irr::core::vector3df> qScale(
-  1, irr::core::vector3df(0.8f, 0.8f, 0.8f));
+      1, irr::core::vector3df(0.8f, 0.8f, 0.8f));
   qScale.resize(7, irr::core::vector3df(0.009f, 0.009f, 0.009f));
 
   irr::core::vector3df position(0.0f, 0.0f, 0.0f);
   std::ostringstream oss;
   oss << "Cube info: row " << x << " col " << y;
   for (auto &tile : tiles_) {
-  if (tile->getName() == oss.str()) {
-    position.set(x * 20.0f, 5.0f, y * 20.0f);
-    tile->getInventory().addItem("food", q0);
-    tile->getInventory().addItem("linemate", q1);
-    tile->getInventory().addItem("deraumere", q2);
-    tile->getInventory().addItem("sibur", q3);
-    tile->getInventory().addItem("mendiane", q4);
-    tile->getInventory().addItem("phiras", q5);
-    tile->getInventory().addItem("thystame", q6);
-    break;
-  }
+    if (tile->getName() == oss.str()) {
+      position.set(x * 20.0f, 5.0f, y * 20.0f);
+      tile->getInventory().addItem("food", q0);
+      tile->getInventory().addItem("linemate", q1);
+      tile->getInventory().addItem("deraumere", q2);
+      tile->getInventory().addItem("sibur", q3);
+      tile->getInventory().addItem("mendiane", q4);
+      tile->getInventory().addItem("phiras", q5);
+      tile->getInventory().addItem("thystame", q6);
+      break;
+    }
   }
   std::vector<int> quantities = {q0, q1, q2, q3, q4, q5, q6};
   int numStones = 0;
   for (size_t i = 1; i < quantities.size(); ++i)
-  if (quantities[i] > 0)
-    ++numStones;
+    if (quantities[i] > 0)
+      ++numStones;
   for (int i = 0; i < quantities[0]; ++i) {
     entity_.push_back(std::make_shared<Stone>(
-      -1, position, qScale[0], stoneTextures[0], qB3D[0], stoneNames[0]));
+        -1, position, qScale[0], stoneTextures[0], qB3D[0], stoneNames[0]));
     entity_.back()->createNode(smgr_, driver_);
   }
   if (numStones == 0)
-  return;
+    return;
 
   float radius = 6.0f;
   float angleStep = 2.0f * M_PI / numStones;
   int placed = 0;
   for (size_t i = 1; i < quantities.size(); ++i) {
-  if (quantities[i] > 0) {
-    float angle = placed * angleStep;
-    irr::core::vector3df objPos = position;
-    objPos.X += std::cos(angle) * radius;
-    objPos.Z += std::sin(angle) * radius;
-    entity_.push_back(std::make_shared<Stone>(
-    -1, objPos, qScale[i], stoneTextures[i], qB3D[i], stoneNames[i]));
-    entity_.back()->createNode(smgr_, driver_);
-    ++placed;
-  }
+    if (quantities[i] > 0) {
+      float angle = placed * angleStep;
+      irr::core::vector3df objPos = position;
+      objPos.X += std::cos(angle) * radius;
+      objPos.Z += std::sin(angle) * radius;
+      entity_.push_back(std::make_shared<Stone>(
+          -1, objPos, qScale[i], stoneTextures[i], qB3D[i], stoneNames[i]));
+      entity_.back()->createNode(smgr_, driver_);
+      ++placed;
+    }
   }
 }
 

--- a/gui/Core/WorldScene.cpp
+++ b/gui/Core/WorldScene.cpp
@@ -227,4 +227,18 @@ void WorldScene::stopIncantation(int x, int y, bool result) {
   }
 }
 
+void WorldScene::killPlayer(int id) {
+  for (auto it = entity_.begin(); it != entity_.end();) {
+    if ((*it)->getId() == id) {
+      auto player = std::dynamic_pointer_cast<PlayerEntity>(*it);
+      if (player)
+        player->getNode()->remove();
+      it = entity_.erase(it);
+      receiver_.removeEntity(id);
+    } else {
+      ++it;
+    }
+  }
+}
+
 void WorldScene::createWorld() {}

--- a/gui/Core/WorldScene.hpp
+++ b/gui/Core/WorldScene.hpp
@@ -72,6 +72,8 @@ public:
 
   std::vector<std::shared_ptr<IEntity>> getEntities() const { return entity_; }
 
+  void killPlayer(int id);
+
 protected:
   irr::IrrlichtDevice *device_;
   irr::scene::ISceneManager *smgr_;

--- a/gui/Event/EventReceiver.cpp
+++ b/gui/Event/EventReceiver.cpp
@@ -8,6 +8,7 @@
 #include "EventReceiver.hpp"
 #include "../Entities/PlayerEntity.hpp"
 #include "../Entities/TileEntity.hpp"
+#include <algorithm>
 #include <iostream>
 #include <string>
 
@@ -292,6 +293,15 @@ void EventReceiver::addCube(TileEntity *c) { cubes.push_back(c); }
 
 void EventReceiver::addEntity(std::shared_ptr<IEntity> entity) {
   entity_.push_back(entity);
+}
+
+void EventReceiver::removeEntity(int id) {
+  auto it = std::remove_if(
+      entity_.begin(), entity_.end(),
+      [id](const std::shared_ptr<IEntity> &e) { return e->getId() == id; });
+  if (it != entity_.end()) {
+    entity_.erase(it, entity_.end());
+  }
 }
 
 void EventReceiver::setText(irr::gui::IGUIStaticText *t) { textCube = t; }

--- a/gui/Event/EventReceiver.hpp
+++ b/gui/Event/EventReceiver.hpp
@@ -26,6 +26,8 @@ public:
 
   void addEntity(std::shared_ptr<IEntity> entity);
 
+  void removeEntity(int id);
+
   void setText(irr::gui::IGUIStaticText *t);
   void setPlayerText(irr::gui::IGUIStaticText *t) { textPlayer = t; }
 

--- a/gui/Network/NetworkClient.hpp
+++ b/gui/Network/NetworkClient.hpp
@@ -65,6 +65,10 @@ public:
       createPlayer(2, 4, 2, Direction::NORTH, 0, "Blue");
     } catch (const std::exception &e) {
     }
+    try {
+      createPlayer(3, 0, 0, Direction::SOUTH, 0, "Red");
+    } catch (const std::exception &e) {
+    }
     contentTiles(2, 4, 32, 32, 32, 32, 32, 32, 32);
     contentTiles(4, 4, 32, 32, 32, 32, 32, 32, 32);
     movePlayer(1, 2, 2, Direction::NORTH);
@@ -82,6 +86,7 @@ public:
     PlayerInventory(1, 0, 2, 1, 1, 1, 14, 1, 1, 1);
     startIncantation(4, 2, 2, {2});
     // stopIncantation(4, 2, true);
+    // killPlayer(3);
   }
 
   std::vector<std::shared_ptr<IEntity>> getEntities() {


### PR DESCRIPTION
This pull request introduces functionality to remove players from the game world and updates related classes to support this feature. Key changes include the addition of a `killPlayer` method in `WorldScene`, a corresponding `removeEntity` method in `EventReceiver`, and updates to the `NetworkClient` class for testing purposes.

### Player Removal Functionality

* [`gui/Core/WorldScene.cpp`](diffhunk://#diff-8a20e60d212969e75144c2825acb91f99f0d7a8a4d57903bb0b7b3debf39d406R230-R243): Added the `killPlayer` method to remove a player entity from the game world and its associated scene node. The method also updates the `EventReceiver` to ensure the entity is properly removed.
* [`gui/Core/WorldScene.hpp`](diffhunk://#diff-785afdcce2bcb7a2416cc57d41784b342a6d32a4f4626b805ddf3a378b4408e0R75-R76): Declared the `killPlayer` method in the `WorldScene` class.

### Event Receiver Updates

* [`gui/Event/EventReceiver.cpp`](diffhunk://#diff-0cce66c1343f178bcb83269ba1dccb2f7519ea728602473f9fb7b84bc5167d65R298-R306): Added the `removeEntity` method to facilitate the removal of entities from the `EventReceiver`'s internal list using `std::remove_if`.
* [`gui/Event/EventReceiver.hpp`](diffhunk://#diff-1fa94ff088c0378814d4b53a8797673fffc88268044a35eac0f25e3b7bc57c64R29-R30): Declared the `removeEntity` method in the `EventReceiver` class.

### Network Client Testing

* [`gui/Network/NetworkClient.hpp`](diffhunk://#diff-402880e8ca71809fec28aeb2e729ca7226b757d0bcbcc3f093149f6170103121R68-R71): Added a test case to create a new player (`Red`) and commented out a call to the `killPlayer` method for future testing of player removal functionality. [[1]](diffhunk://#diff-402880e8ca71809fec28aeb2e729ca7226b757d0bcbcc3f093149f6170103121R68-R71) [[2]](diffhunk://#diff-402880e8ca71809fec28aeb2e729ca7226b757d0bcbcc3f093149f6170103121R89)