### PR TITLE
PR(server) : Death command

### DIFF
--- a/server/src/death.c
+++ b/server/src/death.c
@@ -28,6 +28,9 @@ void death_check(player_t **players, int player_count, map_t *map,
     for (int i = 0; i < player_count; i++) {
         if (players[i] && players[i]->food <= 0) {
             printf("Player %d died of hunger!\n", players[i]->id);
+            zn_send_message(server->connection->zn_server,
+                "dead");
+            players[i]->dead = true;
             death_handle(players[i], map, server);
             players[i] = NULL;
         }


### PR DESCRIPTION
This pull request includes a change to the `death_check` function in `server/src/death.c`. The change ensures that a message is sent to the server when a player dies of hunger, and the player's `dead` status is updated accordingly.

Gameplay mechanics:

* [`server/src/death.c`](diffhunk://#diff-086896d7d02cef2255b18b1a63e8673a363336a8a816ea906e3808524b5499ceR31-R33): Added a call to `zn_send_message` to notify the server with a "dead" message and updated the player's `dead` status to `true` when they die of hunger.