### PR TITLE
PR(GUI): death of an egg

### DIFF
--- a/gui/Core/WorldScene.cpp
+++ b/gui/Core/WorldScene.cpp
@@ -316,7 +316,6 @@ void WorldScene::killPlayer(int id) {
 
 void WorldScene::killEgg(int id) {
   for (auto it = entity_.begin(); it != entity_.end();) {
-    std::cout << "Checking entity with ID: " << (*it)->getId() << std::endl;
     if ((*it)->getId() == -7) {
       std::cout << "Killing egg with ID: " << id << std::endl;
       auto egg = std::dynamic_pointer_cast<Egg>(*it);

--- a/gui/Core/WorldScene.cpp
+++ b/gui/Core/WorldScene.cpp
@@ -314,6 +314,23 @@ void WorldScene::killPlayer(int id) {
   }
 }
 
+void WorldScene::killEgg(int id) {
+  for (auto it = entity_.begin(); it != entity_.end();) {
+    std::cout << "Checking entity with ID: " << (*it)->getId() << std::endl;
+    if ((*it)->getId() == -7) {
+      std::cout << "Killing egg with ID: " << id << std::endl;
+      auto egg = std::dynamic_pointer_cast<Egg>(*it);
+      if (egg)
+        egg->getNode()->remove();
+      it = entity_.erase(it);
+      receiver_.removeEntity(id);
+      addChatMessage("Egg " + std::to_string(id) + " has been killed.");
+    } else {
+      ++it;
+    }
+  }
+}
+
 void WorldScene::addChatMessage(const std::string &message) {
   std::string fullMessage = "Action: " + message;
   chatMessages_.push_back(fullMessage);
@@ -533,4 +550,3 @@ void WorldScene::expulsion(int id) {
     }
   }
 }
-

--- a/gui/Core/WorldScene.hpp
+++ b/gui/Core/WorldScene.hpp
@@ -94,6 +94,8 @@ public:
 
   void killPlayer(int id);
 
+  void killEgg(int id);
+
   void addChatMessage(const std::string &message);
 
   void broadcast(int id, const std::string &message);

--- a/gui/Network/NetworkClient.hpp
+++ b/gui/Network/NetworkClient.hpp
@@ -148,8 +148,8 @@ public:
     // movePlayer(2, 4, 2, Direction::NORTH);
     PlayerInventory(1, 0, 2, 1, 1, 1, 14, 1, 1, 1);
     startIncantation(4, 4, 6, {9});
-    // stopIncantation(4, 4, true);
-    // killPlayer(3);
+    stopIncantation(4, 4, true);
+    killPlayer(3);
     broadcast(1, "Hello from player 1!");
     broadcast(2, "Hello from player 2!");
     createEgg(4);
@@ -158,7 +158,14 @@ public:
     createEgg(6);
     createEgg(7);
     createEgg(8);
-    expulsion(1);
+    killEgg(4);
+    killEgg(5);
+    killEgg(1);
+    killEgg(6);
+    killEgg(7);
+    killEgg(8);
+    // killPlayer(1);
+    // expulsion(1);
     // endGame("Red");
   }
 


### PR DESCRIPTION
This pull request introduces a new method, `killEgg`, to the `WorldScene` class and updates its usage in the `NetworkClient` class. The changes primarily involve adding functionality for removing egg entities from the game world and broadcasting relevant messages. Below is a summary of the most important changes:

### New functionality: Egg removal

* **Added `killEgg` method to `WorldScene`:** This method iterates through entities, identifies eggs by their ID, removes them from the scene, erases them from the entity list, and broadcasts a chat message indicating the egg has been killed. (`gui/Core/WorldScene.cpp`, `[gui/Core/WorldScene.cppR317-R333](diffhunk://#diff-8a20e60d212969e75144c2825acb91f99f0d7a8a4d57903bb0b7b3debf39d406R317-R333)`)
* **Declared `killEgg` in `WorldScene` class:** The new method is added to the class definition in the header file. (`gui/Core/WorldScene.hpp`, `[gui/Core/WorldScene.hppR97-R98](diffhunk://#diff-785afdcce2bcb7a2416cc57d41784b342a6d32a4f4626b805ddf3a378b4408e0R97-R98)`)

### Updates to `NetworkClient`

* **Replaced `expulsion` calls with `killEgg`:** In the `NetworkClient` class, calls to `expulsion` have been replaced with calls to `killEgg` for specific egg IDs. This change aligns with the new functionality for handling egg entities. (`gui/Network/NetworkClient.hpp`, `[gui/Network/NetworkClient.hppL161-R168](diffhunk://#diff-402880e8ca71809fec28aeb2e729ca7226b757d0bcbcc3f093149f6170103121L161-R168)`)
* **Uncommented `killPlayer` and `stopIncantation`:** These methods are now active in the `NetworkClient` class, suggesting they are being tested or used in the current implementation. (`gui/Network/NetworkClient.hpp`, `[gui/Network/NetworkClient.hppL151-R152](diffhunk://#diff-402880e8ca71809fec28aeb2e729ca7226b757d0bcbcc3f093149f6170103121L151-R152)`)