### PR TITLE
PR(Server) : Eject command

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -11,41 +11,42 @@ NAME_TESTS	=	unit_tests
 CC		=	gcc
 RM		=	rm -f
 
-SRCS	=	src/main.c				\
-            src/display_help.c 		\
-            src/display_infos.c 	\
-            src/fill_n_c_f.c 		\
-            src/fill_p_x_y.c 		\
-			src/handle_free.c 		\
-			src/parsing.c 			\
-			src/set_server.c 		\
-			src/error_handling.c 	\
-			src/handle_client.c 	\
-			src/client_manager.c 	\
-			src/commands_movement.c	\
-			src/commands_actions.c 	\
-			src/commands_communication.c \
-			src/commands_core.c 	\
-			src/death.c 			\
-			src/win.c 				\
-			src/game_loop.c 		\
-			src/resource.c 			\
-			src/world.c 			\
-			src/player.c 			\
-			src/elevation.c 		\
-			src/team.c 				\
-			src/look_cmd.c 			\
-			src/look_vision_tiles.c \
-			src/look_current_tile.c \
-			src/inventory_cmd.c 	\
-			src/broadcast_cmd.c 	\
-			src/network_integration.c \
-			src/client_adapters.c 	\
-			src/write_to_client.c 	\
-			src/server_loop.c 		\
-			src/catch_commands_from_clients.c \
-			src/egg.c 			\
-			src/world_utils.c \
+SRCS	=	src/main.c							\
+            src/display_help.c 					\
+            src/display_infos.c 				\
+            src/fill_n_c_f.c 					\
+            src/fill_p_x_y.c 					\
+			src/handle_free.c 					\
+			src/parsing.c 						\
+			src/set_server.c 					\
+			src/error_handling.c 				\
+			src/handle_client.c 				\
+			src/client_manager.c 				\
+			src/commands_movement.c				\
+			src/commands_actions.c 				\
+			src/commands_communication.c 		\
+			src/commands_core.c 				\
+			src/death.c 						\
+			src/win.c 							\
+			src/game_loop.c 					\
+			src/resource.c 						\
+			src/world.c 						\
+			src/player.c 						\
+			src/elevation.c 					\
+			src/team.c 							\
+			src/look_cmd.c 						\
+			src/look_vision_tiles.c 			\
+			src/look_current_tile.c 			\
+			src/inventory_cmd.c 				\
+			src/broadcast_cmd.c 				\
+			src/network_integration.c 			\
+			src/client_adapters.c 				\
+			src/write_to_client.c 				\
+			src/server_loop.c 					\
+			src/catch_commands_from_clients.c 	\
+			src/egg.c 							\
+			src/world_utils.c 					\
+			src/eject_cmd.c 					\
 
 OBJS	=	$(SRCS:.c=.o)
 

--- a/server/include/commands.h
+++ b/server/include/commands.h
@@ -16,6 +16,8 @@
 
 struct server_s;
 typedef struct server_s server_t;
+struct client_s;
+typedef struct client_s client_t;
 
 typedef struct command_s {
     char *name;
@@ -53,5 +55,11 @@ char *get_player_inventory(player_t *player);
 char *get_broadcast_message(player_t *player);
 void broadcast_to_all_players(player_t *sender, server_t *server,
     const char *message);
+
+int make_player_array(tile_t *current_tile, player_t *player,
+    server_t *server, client_t *ejecting_client);
+void destroy_eggs_on_tile(tile_t *tile, server_t *server);
+client_t *find_client_by_player(server_t *server, player_t *player);
+size_t get_nb_player(tile_t *tile, player_t *player);
 
 #endif // COMMANDS_H

--- a/server/src/commands_actions.c
+++ b/server/src/commands_actions.c
@@ -8,11 +8,29 @@
 #include "../include/commands.h"
 #include "../include/server.h"
 #include "../include/world.h"
+#include "../include/team.h"
 
 void cmd_eject(player_t *player, server_t *server)
 {
-    (void) server;
-    printf("Player %d executed eject command\n", player->id);
+    tile_t *current_tile;
+    size_t players_to_eject_count = 0;
+    client_t *ejecting_client;
+
+    if (player->dead || player->in_elevation)
+        return (void)zn_send_message(server->connection->zn_server, "ko");
+    current_tile = get_tile(server->map, player->x, player->y);
+    if (!current_tile)
+        return (void)zn_send_message(server->connection->zn_server, "ko");
+    ejecting_client = find_client_by_player(server, player);
+    if (!ejecting_client)
+        return (void)zn_send_message(server->connection->zn_server, "ko");
+    players_to_eject_count = get_nb_player(current_tile, player);
+    if (players_to_eject_count == 0) {
+        destroy_eggs_on_tile(current_tile, server);
+        return (void)zn_send_message(ejecting_client->zn_sock, "ok");
+    }
+    if (make_player_array(current_tile, player, server, ejecting_client) == -1)
+        return (void)zn_send_message(ejecting_client->zn_sock, "ko");
 }
 
 void cmd_take(player_t *player, server_t *server)

--- a/server/src/eject_cmd.c
+++ b/server/src/eject_cmd.c
@@ -1,0 +1,134 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappynian
+** File description:
+** eject_cmd
+*/
+
+#include "../include/commands.h"
+#include "../include/server.h"
+#include "../include/world.h"
+#include "../include/team.h"
+
+client_t *find_client_by_player(server_t *server,
+    player_t *target_player)
+{
+    client_t *client;
+    player_t *player;
+
+    for (int i = 0; i < server->connection->client_count; i++) {
+        client = server->connection->clients[i];
+        if (!client || client->type != CLIENT_IA || !client->team_name)
+            continue;
+        player = find_player_by_client(server->connection, client);
+        if (player == target_player)
+            return client;
+    }
+    return NULL;
+}
+
+static void move_player_in_direction(player_t *player, int direction,
+    map_t *map)
+{
+    int new_x = player->x;
+    int new_y = player->y;
+
+    switch (direction) {
+        case NORTH:
+            new_y = (new_y - 1 + (int)map->height) % (int)map->height;
+            break;
+        case EAST:
+            new_x = (new_x + 1) % (int)map->width;
+            break;
+        case SOUTH:
+            new_y = (new_y + 1) % (int)map->height;
+            break;
+        case WEST:
+            new_x = (new_x - 1 + (int)map->width) % (int)map->width;
+            break;
+    }
+    move_player(player, new_x, new_y, map);
+}
+
+static int get_dir(player_t *ejected_player,
+    player_t *ejector_player)
+{
+    int dx = ejected_player->x - ejector_player->x;
+    int dy = ejected_player->y - ejector_player->y;
+
+    if (dx == 0 && dy == 0)
+        return 0;
+    if (dy > 0)
+        return 3;
+    if (dy < 0)
+        return 7;
+    if (dx > 0)
+        return 1;
+    if (dx < 0)
+        return 5;
+    return 0;
+}
+
+void destroy_eggs_on_tile(tile_t *tile, server_t *server)
+{
+    (void)tile;
+    (void)server;
+}
+
+size_t get_nb_player(tile_t *tile, player_t *player)
+{
+    size_t count = 0;
+
+    for (size_t i = 0; i < tile->player_count; i++) {
+        if (tile->players[i] != player)
+            count++;
+    }
+    return count;
+}
+
+static void ejection(player_t *player, server_t *server,
+    player_t **players_to_eject, tile_t *current_tile)
+{
+    char msg[64];
+    tile_t *new_tile;
+    player_t *ejected;
+    client_t *ejected_client;
+
+    for (size_t i = 0; i < get_nb_player(current_tile, player); i++) {
+        ejected = players_to_eject[i];
+        ejected_client = find_client_by_player(server, ejected);
+        if (ejected_client) {
+            snprintf(msg, sizeof(msg), "eject: %d", get_dir(ejected, player));
+            zn_send_message(ejected_client->zn_sock, msg);
+        }
+        remove_player_from_tile(current_tile, ejected);
+        move_player_in_direction(ejected, player->orientation,
+            server->map);
+        new_tile = get_tile(server->map, ejected->x, ejected->y);
+        if (new_tile)
+            add_player_to_tile(new_tile, ejected);
+    }
+}
+
+int make_player_array(tile_t *current_tile, player_t *player, server_t *server,
+    client_t *ejecting_client)
+{
+    size_t idx = 0;
+    player_t **players_to_eject;
+    size_t count = get_nb_player(current_tile, player);
+
+    players_to_eject = malloc(sizeof(player_t *) * count);
+    if (!players_to_eject)
+        return -1;
+    for (size_t i = 0; i < current_tile->player_count; i++) {
+        if (current_tile->players[i] != player) {
+            idx++;
+            players_to_eject[idx] = current_tile->players[i];
+        }
+    }
+    ejection(player, server, players_to_eject, current_tile);
+    destroy_eggs_on_tile(current_tile, server);
+    zn_send_message(ejecting_client->zn_sock, "ok");
+    free(players_to_eject);
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces the implementation of a new "eject" command in the server module, enabling players to eject others from their current tile. The changes include updates to various files to support the new functionality, such as adding helper functions, modifying the command structure, and creating a dedicated source file for the eject command logic.

### New "Eject" Command Implementation:

* **Command Logic**: Added the `cmd_eject` function in `server/src/commands_actions.c` to handle the eject command. It checks player conditions, retrieves the current tile, and performs the ejection process.
* **Helper Functions**: Introduced helper functions such as `find_client_by_player`, `get_nb_player`, `destroy_eggs_on_tile`, and `make_player_array` in the new `server/src/eject_cmd.c` file to manage player ejection and related operations.

### Updates to Header Files:

* **Command Structure**: Added `client_t` type definition and new function prototypes in `server/include/commands.h` to support the eject command. [[1]](diffhunk://#diff-99b8f94ea18c4dd140918fbaa7c3309d9d76944f8f02173617de5b50586438d7R19-R20) [[2]](diffhunk://#diff-99b8f94ea18c4dd140918fbaa7c3309d9d76944f8f02173617de5b50586438d7R59-R64)

### Makefile Update:

* **Source File Inclusion**: Added `src/eject_cmd.c` to the `SRCS` variable in `server/Makefile` to include the new source file in the build process.