### PR TITLE
PR(Server) : set object command

### DIFF
--- a/server/include/world.h
+++ b/server/include/world.h
@@ -32,6 +32,7 @@ tile_t *get_tile(map_t *map, size_t x, size_t y);
 void add_player_to_tile(tile_t *tile, player_t *player);
 void remove_player_from_tile(tile_t *tile, player_t *player);
 bool take_resource_from_tile(tile_t *tile, int resource_type);
+bool set_resource_on_tile(tile_t *tile, int resource_type);
 int get_resource_type_from_name(const char *resource_name);
 
 #endif // WORLD_H

--- a/server/src/commands_actions.c
+++ b/server/src/commands_actions.c
@@ -71,7 +71,8 @@ void cmd_set(player_t *player, server_t *server)
     }
     current_tile = get_tile(server->map, player->x, player->y);
     if (set_resource_on_tile(current_tile, resource_type)) {
-        player->resources[resource_type]--;
+        if (player->resources[resource_type] > 0)
+            player->resources[resource_type]--;
         zn_send_message(server->connection->zn_server, "ok");
     } else
         zn_send_message(server->connection->zn_server, "ko");

--- a/server/src/commands_actions.c
+++ b/server/src/commands_actions.c
@@ -70,10 +70,12 @@ void cmd_set(player_t *player, server_t *server)
         return;
     }
     current_tile = get_tile(server->map, player->x, player->y);
-    if (set_resource_on_tile(current_tile, resource_type)) {
-        if (player->resources[resource_type] > 0)
+    if (player->resources[resource_type] > 0) {
+        if (set_resource_on_tile(current_tile, resource_type)) {
             player->resources[resource_type]--;
-        zn_send_message(server->connection->zn_server, "ok");
+            zn_send_message(server->connection->zn_server, "ok");
+        } else
+            zn_send_message(server->connection->zn_server, "ko");
     } else
         zn_send_message(server->connection->zn_server, "ko");
 }

--- a/server/src/commands_actions.c
+++ b/server/src/commands_actions.c
@@ -40,8 +40,22 @@ void cmd_take(player_t *player, server_t *server)
 
 void cmd_set(player_t *player, server_t *server)
 {
-    (void) server;
-    printf("Player %d executed set command\n", player->id);
+    int resource_type;
+    tile_t *current_tile;
+
+    if (player->dead || player->in_elevation)
+        return (void)zn_send_message(server->connection->zn_server, "ko");
+    resource_type = get_resource_type_from_name(get_command_argument(player));
+    if (resource_type == -1) {
+        zn_send_message(server->connection->zn_server, "ko");
+        return;
+    }
+    current_tile = get_tile(server->map, player->x, player->y);
+    if (set_resource_on_tile(current_tile, resource_type)) {
+        player->resources[resource_type]--;
+        zn_send_message(server->connection->zn_server, "ok");
+    } else
+        zn_send_message(server->connection->zn_server, "ko");
 }
 
 void cmd_incantation(player_t *player, server_t *server)

--- a/server/src/world_utils.c
+++ b/server/src/world_utils.c
@@ -32,3 +32,11 @@ bool take_resource_from_tile(tile_t *tile, int resource_type)
     }
     return false;
 }
+
+bool set_resource_on_tile(tile_t *tile, int resource_type)
+{
+    if (!tile || resource_type < 0 || resource_type >= RESOURCE_COUNT)
+        return false;
+    tile->resources[resource_type]++;
+    return true;
+}


### PR DESCRIPTION
This pull request introduces a new feature to allow players to set resources on tiles in the game world. It includes updates to the `set` command, a new utility function for modifying tile resources, and an addition to the tile-related API in the header file.

### Command functionality updates:
* [`server/src/commands_actions.c`](diffhunk://#diff-dddeb60be2400adbfcbb7a31ca44a947beb751e2a974c7000de608aaee217abcL62-R77): Enhanced the `cmd_set` function to allow players to set resources on their current tile. It validates the resource type, checks player state, and adjusts the player's resource inventory accordingly.

### Tile resource management:
* [`server/src/world_utils.c`](diffhunk://#diff-29bbccd201db6d04a20dc428396ecf6a4ce6201858298835621cac98d04f0204R35-R42): Added a new function `set_resource_on_tile`, which increments the specified resource on a given tile, ensuring validity checks for the tile and resource type.

### API updates:
* [`server/include/world.h`](diffhunk://#diff-362d84ddb94b8fe1339e9df1193ac01a3760dabe81084827f99d6a5df393d353R35): Added the declaration for the new `set_resource_on_tile` function to the tile-related API.