### PR TITLE
Fix zappynet read

### DIFF
--- a/libzappy_net/Makefile
+++ b/libzappy_net/Makefile
@@ -43,6 +43,7 @@ SRC_C = $(SRC_DIR)/libzappy_net.c \
         $(SRC_DIR)/zappy_net_ringbuf_read.c \
         $(SRC_DIR)/zappy_net_ringbuf_flush.c \
         $(SRC_DIR)/zappy_net_ringbuf_read_fd.c \
+        $(SRC_DIR)/zappy_net_ringbuf_read_helpers.c \
         $(SRC_DIR)/zappy_net_io.c \
         $(SRC_DIR)/zappy_net_readline.c \
         $(SRC_DIR)/zappy_net_handshake_client.c \

--- a/libzappy_net/include/zappy_net_ringbuf.h
+++ b/libzappy_net/include/zappy_net_ringbuf.h
@@ -35,6 +35,14 @@ typedef struct zn_ringbuf {
     int is_empty;          /**< Flag indicating if buffer is empty */
 } zn_ringbuf_t;
 
+typedef struct read_wrap_params {
+    zn_ringbuf_t *rb;
+    int fd;
+    size_t available;
+    ssize_t bytes_read;
+    size_t first_chunk;
+} read_wrap_params_t;
+
 /**
  * @brief Initialize a ring buffer with given capacity
  *
@@ -147,5 +155,14 @@ int zn_ringbuf_is_full(const zn_ringbuf_t *rb);
  * @return Number of newline characters found
  */
 int zn_count_newlines(const uint8_t *data, size_t len);
+
+/* Helper functions for ring buffer read operations */
+ssize_t handle_wrap_read_first(zn_ringbuf_t *rb, int fd, size_t first_chunk);
+ssize_t handle_wrap_read_second(zn_ringbuf_t *rb, int fd, size_t second_chunk,
+    ssize_t first_bytes_read);
+void update_write_pos_after_wrap(zn_ringbuf_t *rb, ssize_t bytes_read,
+    size_t first_chunk, ssize_t result);
+int validate_read_fd_params(zn_ringbuf_t *rb, int fd);
+int check_line_limit_after_read(zn_ringbuf_t *rb, ssize_t bytes_read);
 
 #endif /* !ZAPPY_NET_RINGBUF_H_ */

--- a/libzappy_net/src/zappy_net_ringbuf_read.c
+++ b/libzappy_net/src/zappy_net_ringbuf_read.c
@@ -7,6 +7,7 @@
 
 #include "../include/zappy_net_ringbuf.h"
 #include <string.h>
+#include <stdio.h>
 
 static void read_no_wrap(zn_ringbuf_t *rb, uint8_t *dst, size_t len)
 {
@@ -58,6 +59,8 @@ ssize_t zn_ringbuf_read(zn_ringbuf_t *rb, void *data, size_t len)
     if (validate_read_params(rb, data, len))
         return 0;
     available = zn_ringbuf_read_available(rb);
+    if (available == 0)
+        return 0;
     len = (len < available) ? len : available;
     newline_count = count_newlines_for_read(rb, len);
     if (rb->read_pos + len <= rb->capacity)
@@ -77,22 +80,32 @@ static int validate_read_line_params(zn_ringbuf_t *rb, void *data,
         max_len == 0 || rb->is_empty);
 }
 
+static void finalize_line_read(zn_ringbuf_t *rb, uint8_t *dst, size_t pos,
+    size_t i)
+{
+    rb->line_count--;
+    rb->read_pos = pos;
+    if (rb->read_pos == rb->write_pos)
+        rb->is_empty = 1;
+    dst[i + 1] = '\0';
+}
+
 static ssize_t read_until_newline(zn_ringbuf_t *rb, uint8_t *dst,
     size_t max_len)
 {
     size_t i;
     size_t pos;
     uint8_t c;
+    size_t available;
 
     pos = rb->read_pos;
-    for (i = 0; i < max_len; i++) {
+    available = zn_ringbuf_read_available(rb);
+    for (i = 0; i < max_len - 1 && i < available; i++) {
         c = rb->buffer[pos];
         dst[i] = c;
         pos = (pos + 1) % rb->capacity;
         if (c == '\n') {
-            rb->line_count--;
-            rb->read_pos = pos;
-            dst[i + 1] = '\0';
+            finalize_line_read(rb, dst, pos, i);
             return i + 1;
         }
     }
@@ -101,16 +114,11 @@ static ssize_t read_until_newline(zn_ringbuf_t *rb, uint8_t *dst,
 
 ssize_t zn_ringbuf_read_line(zn_ringbuf_t *rb, void *data, size_t max_len)
 {
-    size_t available;
     uint8_t *dst = (uint8_t *)data;
-    ssize_t result;
 
     if (validate_read_line_params(rb, data, max_len))
         return -1;
-    available = zn_ringbuf_read_available(rb);
-    max_len = (max_len < available) ? max_len : available;
-    result = read_until_newline(rb, dst, max_len);
-    if (rb->read_pos == rb->write_pos)
-        rb->is_empty = 1;
-    return result;
+    if (rb->line_count == 0)
+        return -1;
+    return read_until_newline(rb, dst, max_len);
 }

--- a/libzappy_net/src/zappy_net_ringbuf_read_fd.c
+++ b/libzappy_net/src/zappy_net_ringbuf_read_fd.c
@@ -20,80 +20,77 @@ static ssize_t read_no_wrap(zn_ringbuf_t *rb, int fd, size_t available)
     return result;
 }
 
-static ssize_t handle_wrap_read_first(zn_ringbuf_t *rb, int fd,
-    size_t first_chunk)
+static ssize_t handle_second_chunk_read(read_wrap_params_t *params)
 {
-    return read(fd, rb->buffer + rb->write_pos, first_chunk);
-}
-
-static ssize_t handle_wrap_read_second(zn_ringbuf_t *rb, int fd,
-    size_t second_chunk, ssize_t bytes_read)
-{
+    size_t second_chunk;
     ssize_t result;
 
-    result = read(fd, rb->buffer, second_chunk);
-    if (result <= 0) {
-        rb->write_pos = (rb->write_pos + bytes_read) % rb->capacity;
-        return bytes_read;
-    }
-    return bytes_read + result;
+    second_chunk = params->available - params->first_chunk;
+    result = handle_wrap_read_second(params->rb, params->fd, second_chunk,
+        params->bytes_read);
+    update_write_pos_after_wrap(params->rb, params->bytes_read,
+        params->first_chunk, result);
+    return (result > params->bytes_read) ? result : params->bytes_read;
 }
 
 static ssize_t read_with_wrap(zn_ringbuf_t *rb, int fd, size_t available)
 {
-    ssize_t bytes_read = 0;
+    read_wrap_params_t params;
     ssize_t result;
-    size_t first_chunk;
-    size_t second_chunk;
 
-    first_chunk = rb->capacity - rb->write_pos;
-    result = handle_wrap_read_first(rb, fd, first_chunk);
+    params.rb = rb;
+    params.fd = fd;
+    params.available = available;
+    params.first_chunk = rb->capacity - rb->write_pos;
+    result = handle_wrap_read_first(rb, fd, params.first_chunk);
     if (result <= 0)
         return result;
-    bytes_read = result;
-    if (bytes_read == (ssize_t)first_chunk) {
-        second_chunk = available - first_chunk;
-        bytes_read = handle_wrap_read_second(rb, fd, second_chunk,
-            bytes_read);
-        if (bytes_read > result)
-            rb->write_pos = bytes_read - result;
-    } else {
-        rb->write_pos += bytes_read;
+    params.bytes_read = result;
+    if (params.bytes_read == (ssize_t)params.first_chunk &&
+        available > params.first_chunk) {
+        return handle_second_chunk_read(&params);
     }
-    return bytes_read;
+    rb->write_pos += params.bytes_read;
+    return params.bytes_read;
 }
 
-static int check_line_limit_after_read(zn_ringbuf_t *rb, ssize_t bytes_read)
+static void update_after_read(zn_ringbuf_t *rb, ssize_t bytes_read,
+    size_t old_write_pos)
 {
-    if (rb->line_count > MAX_QUEUED_LINES) {
-        rb->write_pos = (rb->write_pos - bytes_read + rb->capacity) %
-            rb->capacity;
-        rb->line_count -= zn_count_newlines(rb->buffer + rb->write_pos,
-            bytes_read);
-        if (rb->read_pos == rb->write_pos)
-            rb->is_empty = 1;
-        errno = ENOBUFS;
-        return -1;
-    }
-    return 0;
-}
+    size_t newlines_count = 0;
+    size_t first_chunk = 0;
+    size_t second_chunk = 0;
 
-static int validate_read_fd_params(zn_ringbuf_t *rb, int fd)
-{
-    return (rb == NULL || rb->buffer == NULL || fd < 0);
-}
-
-static void update_after_read(zn_ringbuf_t *rb, ssize_t bytes_read)
-{
     rb->is_empty = 0;
-    rb->line_count += zn_count_newlines(rb->buffer + rb->write_pos -
-        bytes_read, bytes_read);
+    if (old_write_pos + bytes_read <= rb->capacity) {
+        newlines_count = zn_count_newlines(rb->buffer + old_write_pos,
+            bytes_read);
+    } else {
+        first_chunk = rb->capacity - old_write_pos;
+        second_chunk = bytes_read - first_chunk;
+        newlines_count = zn_count_newlines(rb->buffer + old_write_pos,
+            first_chunk);
+        if (second_chunk > 0) {
+            newlines_count += zn_count_newlines(rb->buffer,
+                second_chunk);
+        }
+    }
+    rb->line_count += newlines_count;
+}
+
+static ssize_t perform_read_operation(zn_ringbuf_t *rb, int fd,
+    size_t available)
+{
+    if (rb->write_pos + available <= rb->capacity)
+        return read_no_wrap(rb, fd, available);
+    return read_with_wrap(rb, fd, available);
 }
 
 ssize_t zn_ringbuf_read_from_fd(zn_ringbuf_t *rb, int fd)
 {
     size_t available;
     ssize_t bytes_read;
+    size_t old_write_pos;
 
     if (validate_read_fd_params(rb, fd))
         return -1;
@@ -102,13 +99,11 @@ ssize_t zn_ringbuf_read_from_fd(zn_ringbuf_t *rb, int fd)
         errno = ENOBUFS;
         return -1;
     }
-    if (rb->write_pos + available <= rb->capacity)
-        bytes_read = read_no_wrap(rb, fd, available);
-    else
-        bytes_read = read_with_wrap(rb, fd, available);
+    old_write_pos = rb->write_pos;
+    bytes_read = perform_read_operation(rb, fd, available);
     if (bytes_read <= 0)
         return bytes_read;
-    update_after_read(rb, bytes_read);
+    update_after_read(rb, bytes_read, old_write_pos);
     if (check_line_limit_after_read(rb, bytes_read) < 0)
         return -1;
     return bytes_read;

--- a/libzappy_net/src/zappy_net_ringbuf_read_helpers.c
+++ b/libzappy_net/src/zappy_net_ringbuf_read_helpers.c
@@ -1,0 +1,50 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappy
+** File description:
+** Zappy Network Library - Ring Buffer Read Helper Functions
+*/
+
+#include "../include/zappy_net_ringbuf.h"
+
+ssize_t handle_wrap_read_first(zn_ringbuf_t *rb, int fd, size_t first_chunk)
+{
+    return read(fd, rb->buffer + rb->write_pos, first_chunk);
+}
+
+ssize_t handle_wrap_read_second(zn_ringbuf_t *rb, int fd, size_t second_chunk,
+    ssize_t first_bytes_read)
+{
+    ssize_t result;
+
+    result = read(fd, rb->buffer, second_chunk);
+    if (result <= 0) {
+        return first_bytes_read;
+    }
+    return first_bytes_read + result;
+}
+
+void update_write_pos_after_wrap(zn_ringbuf_t *rb, ssize_t bytes_read,
+    size_t first_chunk, ssize_t result)
+{
+    if (result > bytes_read) {
+        rb->write_pos = result - first_chunk;
+    } else {
+        rb->write_pos = 0;
+    }
+}
+
+int validate_read_fd_params(zn_ringbuf_t *rb, int fd)
+{
+    return (rb == NULL || rb->buffer == NULL || fd < 0);
+}
+
+int check_line_limit_after_read(zn_ringbuf_t *rb, ssize_t bytes_read)
+{
+    (void)bytes_read;
+    if (rb->line_count > MAX_QUEUED_LINES) {
+        errno = ENOBUFS;
+        return -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces enhancements and refactoring to the `libzappy_net` library, focusing on improving the readability, modularity, and robustness of the ring buffer read operations. Key changes include the addition of helper functions, the introduction of a new structure for managing wrapped reads, and streamlined logic for handling line reads and buffer updates.

### Enhancements to modularity and code organization:
* Added a new file `zappy_net_ringbuf_read_helpers.c` to encapsulate helper functions for wrapped reads, buffer updates, and parameter validation. This improves code organization and reusability.
* Updated the `Makefile` to include the new `zappy_net_ringbuf_read_helpers.c` file in the build process.

### Improvements to ring buffer read operations:
* Introduced a new `read_wrap_params_t` structure in `zappy_net_ringbuf.h` to simplify parameter management for wrapped read operations.
* Refactored the wrapped read logic in `zappy_net_ringbuf_read_fd.c` by replacing inline implementations with reusable helper functions, improving maintainability. [[1]](diffhunk://#diff-3366573de71d3db05e902ec284055667383c8403fbcda257f320e554d774c0f9L23-R93) [[2]](diffhunk://#diff-3366573de71d3db05e902ec284055667383c8403fbcda257f320e554d774c0f9L105-R106)

### Enhancements to line read functionality:
* Added a `finalize_line_read` helper function to streamline the logic for completing line reads in `zappy_net_ringbuf_read.c`.
* Simplified the `zn_ringbuf_read_line` function by removing redundant checks and delegating logic to helper functions.

### Minor improvements:
* Added a check to ensure zero-length reads are handled gracefully in `zn_ringbuf_read`.
* Included the `<stdio.h>` header in `zappy_net_ringbuf_read.c` for debugging or logging purposes.