### PR TITLE
166 net fix poll usage

### DIFF
--- a/libzappy_net/include/zappy_net.h
+++ b/libzappy_net/include/zappy_net.h
@@ -100,20 +100,6 @@
     void zn_socket_cleanup(zn_socket_t socket);
 
     /**
-     * @brief Write data to the socket's send buffer
-     *
-     * This function writes data to the socket's internal send buffer.
-     * The data is not immediately sent over the network but queued for
-     * later transmission when zn_flush() is called.
-     *
-     * @param sock The socket handle
-     * @param data Pointer to data to write
-     * @param len Length of data in bytes
-     * @return Number of bytes written, -1 on error with errno set
-     */
-    ssize_t zn_write(zn_socket_t sock, const void *data, size_t len);
-
-    /**
      * @brief Flush the socket's send buffer to the network
      *
      * This function attempts to send all data in the socket's send buffer

--- a/libzappy_net/include/zappy_net.h
+++ b/libzappy_net/include/zappy_net.h
@@ -114,49 +114,6 @@
     ssize_t zn_write(zn_socket_t sock, const void *data, size_t len);
 
     /**
-     * @brief Read data from the socket's receive buffer
-     *
-     * This function reads data from the socket's internal receive buffer.
-     * If the buffer is empty, it attempts to read from the socket into
-     * the buffer first. This function does not block if no data is available.
-     *
-     * @param sock The socket handle
-     * @param data Buffer to store read data
-     * @param len Maximum amount of data to read
-     * @return Number of bytes read, -1 on error with errno set, 0 if no data
-     */
-    ssize_t zn_read(zn_socket_t sock, void *data, size_t len);
-
-    /**
-     * @brief Read a line from the socket's receive buffer
-     *
-     * This function reads a complete line (ending with '\n') from the socket's
-     * internal receive buffer. If no complete line is available, it attempts
-     * to read from the socket into the buffer first.
-     *
-     * @param sock The socket handle
-     * @param data Buffer to store read data
-     * @param len Maximum amount of data to read
-     * @return Number of bytes read (including newline), -1 on error or no line
-     */
-    ssize_t zn_readln(zn_socket_t sock, void *data, size_t len);
-
-    /**
-     * @brief Read a complete line from socket with partial segment support
-     *
-     * This function reads a complete newline-terminated line from the socket.
-     * It handles TCP fragmentation by accumulating partial segments until
-     * a complete line is available. Returns dynamically allocated string
-     * containing the complete line (without newline) or NULL if no complete
-     * line is available.
-     *
-     * @param sock The socket handle
-     * @return Dynamically allocated string with complete line (caller must
-     *         free), or NULL if no complete line available or on error
-     */
-    char *zn_readline(zn_socket_t sock);
-
-    /**
      * @brief Flush the socket's send buffer to the network
      *
      * This function attempts to send all data in the socket's send buffer

--- a/libzappy_net/src/zappy_net_handshake_utils.c
+++ b/libzappy_net/src/zappy_net_handshake_utils.c
@@ -5,7 +5,6 @@
 ** Handshake message handling utilities
 */
 
-#include "zappy_net.h"
 #include "zappy_net_internal.h"
 
 int zn_send_message(zn_socket_t sock, const char *message)

--- a/libzappy_net/src/zappy_net_internal.h
+++ b/libzappy_net/src/zappy_net_internal.h
@@ -15,40 +15,47 @@
     #include <stdio.h>
     #include <stdlib.h>
 
-/**
- * @brief Internal socket structure definition
- */
-struct zn_socket {
-    int fd;
-    int initialized;
-    struct sockaddr_in addr;
-    int type;
-    zn_ringbuf_t read_buffer;  /* Buffer for reading from socket */
-    zn_ringbuf_t write_buffer; /* Buffer for writing to socket */
-    int buffer_initialized;    /* Flag to track if buffers are initialized */
-};
+    /**
+    * @brief Internal socket structure definition
+    */
+    struct zn_socket {
+        int fd;
+        int initialized;
+        struct sockaddr_in addr;
+        int type;
+        zn_ringbuf_t read_buffer;  /* Buffer for reading from socket */
+        zn_ringbuf_t write_buffer; /* Buffer for writing to socket */
+        int buffer_initialized;    /* Flag to track if buffers are initialized */
+    };
 
-/**
- * @brief Internal handshake utility functions
- */
-int zn_send_message(zn_socket_t sock, const char *message);
-char *zn_receive_message(zn_socket_t sock);
+    /**
+    * @brief Read a complete line from socket with partial segment support
+    *
+    * This function reads a complete newline-terminated line from the socket.
+    * It handles TCP fragmentation by accumulating partial segments until
+    * a complete line is available. Returns dynamically allocated string
+    * containing the complete line (without newline) or NULL if no complete
+    * line is available.
+    *
+    * @param sock The socket handle
+    * @return Dynamically allocated string with complete line (caller must
+    *         free), or NULL if no complete line available or on error
+    */
 
+    char *zn_readline(zn_socket_t sock);
 
-/**
- * @brief Read a complete line from socket with partial segment support
- *
- * This function reads a complete newline-terminated line from the socket.
- * It handles TCP fragmentation by accumulating partial segments until
- * a complete line is available. Returns dynamically allocated string
- * containing the complete line (without newline) or NULL if no complete
- * line is available.
- *
- * @param sock The socket handle
- * @return Dynamically allocated string with complete line (caller must
- *         free), or NULL if no complete line available or on error
- */
-char *zn_readline(zn_socket_t sock);
-
+    /**
+     * @brief Write data to the socket's send buffer
+     *
+     * This function writes data to the socket's internal send buffer.
+     * The data is not immediately sent over the network but queued for
+     * later transmission when zn_flush() is called.
+     *
+     * @param sock The socket handle
+     * @param data Pointer to data to write
+     * @param len Length of data in bytes
+     * @return Number of bytes written, -1 on error with errno set
+     */
+    ssize_t zn_write(zn_socket_t sock, const void *data, size_t len);
 
 #endif /* !ZAPPY_NET_INTERNAL_H_ */

--- a/libzappy_net/src/zappy_net_internal.h
+++ b/libzappy_net/src/zappy_net_internal.h
@@ -34,4 +34,21 @@ struct zn_socket {
 int zn_send_message(zn_socket_t sock, const char *message);
 char *zn_receive_message(zn_socket_t sock);
 
+
+/**
+ * @brief Read a complete line from socket with partial segment support
+ *
+ * This function reads a complete newline-terminated line from the socket.
+ * It handles TCP fragmentation by accumulating partial segments until
+ * a complete line is available. Returns dynamically allocated string
+ * containing the complete line (without newline) or NULL if no complete
+ * line is available.
+ *
+ * @param sock The socket handle
+ * @return Dynamically allocated string with complete line (caller must
+ *         free), or NULL if no complete line available or on error
+ */
+char *zn_readline(zn_socket_t sock);
+
+
 #endif /* !ZAPPY_NET_INTERNAL_H_ */

--- a/server/src/write_to_client.c
+++ b/server/src/write_to_client.c
@@ -9,15 +9,9 @@
 
 void send_to_client(client_t *client, const char *msg)
 {
-    int len;
-
     if (!client || !msg || !client->zn_sock)
         return;
-    len = strlen(msg);
-    if (len > 0) {
-        zn_write(client->zn_sock, msg, len);
-        zn_flush(client->zn_sock);
-    }
+    zn_send_message(client->zn_sock, msg);
 }
 
 void handle_client_write(server_connection_t *connection, int client_idx)


### PR DESCRIPTION
This pull request focuses on refactoring and simplifying the socket I/O interface in the `libzappy_net` library. It removes several redundant or unused functions and consolidates functionality to improve maintainability and clarity. The major changes include removing legacy socket read/write methods, introducing a streamlined `zn_send_message` function, and updating related internal structures and files.

### Removal of legacy socket I/O functions:
* Removed the following functions from `zappy_net.h` and their implementations in `zappy_net_io.c`:
  - `zn_write`, `zn_read`, `zn_readln`, `zn_readline`, and `zn_has_data` [[1]](diffhunk://#diff-6cc188dde7dd354b8e590c4f7f4cb7931407c74701174b84a395e55f670f4866L102-L158) [[2]](diffhunk://#diff-f9041c330f24985e5936a8cb9f2b7f9e431f61f242df393cc4cde57126ec0254L77-L107) [[3]](diffhunk://#diff-f9041c330f24985e5936a8cb9f2b7f9e431f61f242df393cc4cde57126ec0254L139-L156) [[4]](diffhunk://#diff-f9041c330f24985e5936a8cb9f2b7f9e431f61f242df393cc4cde57126ec0254L179-L214).

### Consolidation of message sending:
* Introduced `zn_send_message` as the primary function for writing data to sockets, replacing direct calls to `zn_write` and `zn_flush` [[1]](diffhunk://#diff-b0bb48fb1f008a742f3b586d9acd285241602dcc6b4a89300912ec1738104240L8) [[2]](diffhunk://#diff-e826f495a4ff9b4aaa597a5251414a4be6371715fee043ddf2b3f957fd665830L12-R14).

### Updates to internal structures:
* Moved the declaration of `zn_readline` and `zn_write` to `zappy_net_internal.h`, indicating they are now internal utilities rather than part of the public API.

These changes simplify the API by removing unused or redundant methods and emphasize the use of higher-level abstractions like `zn_send_message`. This refactor improves the maintainability of the codebase while retaining all necessary functionality.