### PR TITLE
PR(server) : Incantation command

### DIFF
--- a/libzappy_net/src/zappy_net_internal.h
+++ b/libzappy_net/src/zappy_net_internal.h
@@ -15,47 +15,47 @@
     #include <stdio.h>
     #include <stdlib.h>
 
-    /**
-    * @brief Internal socket structure definition
-    */
-    struct zn_socket {
-        int fd;
-        int initialized;
-        struct sockaddr_in addr;
-        int type;
-        zn_ringbuf_t read_buffer;  /* Buffer for reading from socket */
-        zn_ringbuf_t write_buffer; /* Buffer for writing to socket */
-        int buffer_initialized;    /* Flag to track if buffers are initialized */
-    };
+/**
+* @brief Internal socket structure definition
+*/
+struct zn_socket {
+    int fd;
+    int initialized;
+    struct sockaddr_in addr;
+    int type;
+    zn_ringbuf_t read_buffer;  /* Buffer for reading from socket */
+    zn_ringbuf_t write_buffer; /* Buffer for writing to socket */
+    int buffer_initialized;    /* Flag to track if buffers are initialized */
+};
 
-    /**
-    * @brief Read a complete line from socket with partial segment support
-    *
-    * This function reads a complete newline-terminated line from the socket.
-    * It handles TCP fragmentation by accumulating partial segments until
-    * a complete line is available. Returns dynamically allocated string
-    * containing the complete line (without newline) or NULL if no complete
-    * line is available.
-    *
-    * @param sock The socket handle
-    * @return Dynamically allocated string with complete line (caller must
-    *         free), or NULL if no complete line available or on error
-    */
+/**
+* @brief Read a complete line from socket with partial segment support
+*
+* This function reads a complete newline-terminated line from the socket.
+* It handles TCP fragmentation by accumulating partial segments until
+* a complete line is available. Returns dynamically allocated string
+* containing the complete line (without newline) or NULL if no complete
+* line is available.
+*
+* @param sock The socket handle
+* @return Dynamically allocated string with complete line (caller must
+*         free), or NULL if no complete line available or on error
+*/
 
-    char *zn_readline(zn_socket_t sock);
+char *zn_readline(zn_socket_t sock);
 
-    /**
-     * @brief Write data to the socket's send buffer
-     *
-     * This function writes data to the socket's internal send buffer.
-     * The data is not immediately sent over the network but queued for
-     * later transmission when zn_flush() is called.
-     *
-     * @param sock The socket handle
-     * @param data Pointer to data to write
-     * @param len Length of data in bytes
-     * @return Number of bytes written, -1 on error with errno set
-     */
-    ssize_t zn_write(zn_socket_t sock, const void *data, size_t len);
+/**
+ * @brief Write data to the socket's send buffer
+ *
+ * This function writes data to the socket's internal send buffer.
+ * The data is not immediately sent over the network but queued for
+ * later transmission when zn_flush() is called.
+ *
+ * @param sock The socket handle
+ * @param data Pointer to data to write
+ * @param len Length of data in bytes
+ * @return Number of bytes written, -1 on error with errno set
+ */
+ssize_t zn_write(zn_socket_t sock, const void *data, size_t len);
 
 #endif /* !ZAPPY_NET_INTERNAL_H_ */

--- a/server/Makefile
+++ b/server/Makefile
@@ -47,6 +47,8 @@ SRCS	=	src/main.c							\
 			src/egg.c 							\
 			src/world_utils.c 					\
 			src/eject_cmd.c 					\
+			src/check_elevation.c 				\
+			src/send_state_msg_to_players.c 	\
 
 OBJS	=	$(SRCS:.c=.o)
 

--- a/server/include/commands.h
+++ b/server/include/commands.h
@@ -58,7 +58,6 @@ void broadcast_to_all_players(player_t *sender, server_t *server,
 
 int make_player_array(tile_t *current_tile, player_t *player,
     server_t *server, client_t *ejecting_client);
-void destroy_eggs_on_tile(tile_t *tile, server_t *server);
 client_t *find_client_by_player(server_t *server, player_t *player);
 size_t get_nb_player(tile_t *tile, player_t *player);
 

--- a/server/include/elevation.h
+++ b/server/include/elevation.h
@@ -36,7 +36,5 @@ void complete_incantation_ritual(player_t *player, server_t *server);
 size_t count_players_with_level(tile_t *tile, player_t *player);
 int check_good_nb_players_and_resources(tile_t *tile,
     elevation_requirement_t *req, player_t *player);
-bool start_incantation_immediately(player_t *player, client_t *client,
-    server_connection_t *connection);
 
 #endif // ELEVATION_H

--- a/server/include/elevation.h
+++ b/server/include/elevation.h
@@ -36,5 +36,7 @@ void complete_incantation_ritual(player_t *player, server_t *server);
 size_t count_players_with_level(tile_t *tile, player_t *player);
 int check_good_nb_players_and_resources(tile_t *tile,
     elevation_requirement_t *req, player_t *player);
+bool start_incantation_immediately(player_t *player, client_t *client,
+    server_connection_t *connection);
 
 #endif // ELEVATION_H

--- a/server/include/elevation.h
+++ b/server/include/elevation.h
@@ -28,5 +28,13 @@ bool complete_incantation(tile_t *tile, int player_level,
 void apply_elevation(tile_t *tile, int player_level,
     const elevation_requirement_t *requirements);
 void cancel_incantation(tile_t *tile, int player_level);
+bool can_start_incantation(tile_t *tile, int player_level,
+    const elevation_requirement_t *requirements);
+void check_and_send_elevation_status(server_t *server, player_t *player,
+    tile_t *current_tile, const elevation_requirement_t *requirements);
+void complete_incantation_ritual(player_t *player, server_t *server);
+size_t count_players_with_level(tile_t *tile, player_t *player);
+int check_good_nb_players_and_resources(tile_t *tile,
+    elevation_requirement_t *req, player_t *player);
 
 #endif // ELEVATION_H

--- a/server/include/elevation.h
+++ b/server/include/elevation.h
@@ -24,9 +24,9 @@ void elevation_init_requirements(elevation_requirement_t *requirements);
 void start_incantation(tile_t *tile, int player_level,
     const elevation_requirement_t *requirements);
 bool complete_incantation(tile_t *tile, int player_level,
-    const elevation_requirement_t *requirements);
+    const elevation_requirement_t *requirements, server_t *server);
 void apply_elevation(tile_t *tile, int player_level,
-    const elevation_requirement_t *requirements);
+    const elevation_requirement_t *requirements, server_t *server);
 void cancel_incantation(tile_t *tile, int player_level);
 bool can_start_incantation(tile_t *tile, int player_level,
     const elevation_requirement_t *requirements);

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -116,5 +116,7 @@ const char **get_resource_names(void);
 
 void send_ko_to_all_players(server_t *server, tile_t *current_tile, size_t i);
 void send_ok_to_all_players(server_t *server, tile_t *current_tile, size_t i);
+void send_stat_to_all_players(server_t *server, tile_t *current_tile,
+    size_t i, const char *stat_msg);
 
 #endif /* SERVER_H */

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -114,4 +114,7 @@ void player_found(player_t *player, const char *line, client_t *client);
 
 const char **get_resource_names(void);
 
+void send_ko_to_all_players(server_t *server, tile_t *current_tile, size_t i);
+void send_ok_to_all_players(server_t *server, tile_t *current_tile, size_t i);
+
 #endif /* SERVER_H */

--- a/server/src/check_elevation.c
+++ b/server/src/check_elevation.c
@@ -1,0 +1,93 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappynian
+** File description:
+** check_elevation
+*/
+
+#include "../include/elevation.h"
+#include "../include/server.h"
+
+bool complete_incantation(tile_t *tile, int player_level,
+    const elevation_requirement_t *requirements)
+{
+    elevation_requirement_t req;
+
+    if (player_level < 1 || player_level > MAX_LEVEL) {
+        return false;
+    }
+    req = requirements[player_level - 1];
+    if (tile->player_count < req.required_players) {
+        return false;
+    }
+    for (int i = 0; i < NB_RESOURCE_TYPES; i++) {
+        if (tile->resources[i] < req.required_resources[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool can_start_incantation(tile_t *tile, int player_level,
+    const elevation_requirement_t *requirements)
+{
+    elevation_requirement_t req;
+
+    if (player_level < 1 || player_level > MAX_LEVEL) {
+        return false;
+    }
+    req = requirements[player_level - 1];
+    if (tile->player_count < req.required_players) {
+        return false;
+    }
+    for (int i = 0; i < NB_RESOURCE_TYPES; i++) {
+        if (tile->resources[i] < req.required_resources[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void check_and_send_elevation_status(server_t *server, player_t *player,
+    tile_t *current_tile, const elevation_requirement_t *requirements)
+{
+    if (complete_incantation(current_tile, player->level, requirements)) {
+        apply_elevation(current_tile, player->level, requirements);
+        for (size_t i = 0; i < current_tile->player_count; i++)
+            send_ok_to_all_players(server, current_tile, i);
+    } else {
+        cancel_incantation(current_tile, player->level);
+        for (size_t i = 0; i < current_tile->player_count; i++)
+            send_ko_to_all_players(server, current_tile, i);
+    }
+}
+
+size_t count_players_with_level(tile_t *tile, player_t *player)
+{
+    size_t count = 0;
+
+    for (size_t i = 0; i < tile->player_count; i++) {
+        if (tile->players[i] &&
+            tile->players[i]->level == player->level) {
+            count++;
+        }
+    }
+    return count;
+}
+
+int check_good_nb_players_and_resources(tile_t *current_tile,
+    elevation_requirement_t *req, player_t *player)
+{
+    size_t same_level_players = 0;
+
+    elevation_init_requirements(req);
+    same_level_players = count_players_with_level(current_tile, player);
+    if (same_level_players < req[player->level - 1].required_players)
+        return -1;
+    for (int i = 0; i < NB_RESOURCE_TYPES; i++) {
+        if (current_tile->resources[i] <
+            req[player->level - 1].required_resources[i])
+            return -1;
+    }
+    return 0;
+}

--- a/server/src/check_elevation.c
+++ b/server/src/check_elevation.c
@@ -51,10 +51,16 @@ bool can_start_incantation(tile_t *tile, int player_level,
 void check_and_send_elevation_status(server_t *server, player_t *player,
     tile_t *current_tile, const elevation_requirement_t *requirements)
 {
+    char response[256];
+
     if (complete_incantation(current_tile, player->level, requirements)) {
         apply_elevation(current_tile, player->level, requirements);
-        for (size_t i = 0; i < current_tile->player_count; i++)
+        snprintf(response, sizeof(response),
+            "Elevation underway Current level: %d", player->level);
+        for (size_t i = 0; i < current_tile->player_count; i++) {
+            send_stat_to_all_players(server, current_tile, i, response);
             send_ok_to_all_players(server, current_tile, i);
+        }
     } else {
         cancel_incantation(current_tile, player->level);
         for (size_t i = 0; i < current_tile->player_count; i++)

--- a/server/src/check_elevation.c
+++ b/server/src/check_elevation.c
@@ -55,15 +55,14 @@ bool can_start_incantation(tile_t *tile, int player_level,
 void check_and_send_elevation_status(server_t *server, player_t *player,
     tile_t *current_tile, const elevation_requirement_t *requirements)
 {
-    char response[256];
+    char msg[256];
 
     if (complete_incantation(current_tile, player->level, requirements,
         server)) {
-        apply_elevation(current_tile, player->level, requirements
-        snprintf(response, sizeof(response),
-            "Current level: %d", player->level);
+        apply_elevation(current_tile, player->level, requirements, server);
+        snprintf(msg, sizeof(msg), "Current level: %d", player->level);
         for (size_t i = 0; i < current_tile->player_count; i++)
-            send_stat_to_all_players(server, current_tile, i, response);
+            send_stat_to_all_players(server, current_tile, i, msg);
     } else {
         cancel_incantation(current_tile, player->level);
         for (size_t i = 0; i < current_tile->player_count; i++)

--- a/server/src/check_elevation.c
+++ b/server/src/check_elevation.c
@@ -9,9 +9,10 @@
 #include "../include/server.h"
 
 bool complete_incantation(tile_t *tile, int player_level,
-    const elevation_requirement_t *requirements)
+    const elevation_requirement_t *requirements, server_t *server)
 {
     elevation_requirement_t req;
+    char response[256];
 
     if (player_level < 1 || player_level > MAX_LEVEL) {
         return false;
@@ -25,6 +26,9 @@ bool complete_incantation(tile_t *tile, int player_level,
             return false;
         }
     }
+    snprintf(response, sizeof(response), "Elevation underway");
+    for (size_t i = 0; i < tile->player_count; i++)
+        send_stat_to_all_players(server, tile, i, response);
     return true;
 }
 
@@ -53,14 +57,13 @@ void check_and_send_elevation_status(server_t *server, player_t *player,
 {
     char response[256];
 
-    if (complete_incantation(current_tile, player->level, requirements)) {
-        apply_elevation(current_tile, player->level, requirements);
+    if (complete_incantation(current_tile, player->level, requirements,
+        server)) {
+        apply_elevation(current_tile, player->level, requirements
         snprintf(response, sizeof(response),
-            "Elevation underway Current level: %d", player->level);
-        for (size_t i = 0; i < current_tile->player_count; i++) {
+            "Current level: %d", player->level);
+        for (size_t i = 0; i < current_tile->player_count; i++)
             send_stat_to_all_players(server, current_tile, i, response);
-            send_ok_to_all_players(server, current_tile, i);
-        }
     } else {
         cancel_incantation(current_tile, player->level);
         for (size_t i = 0; i < current_tile->player_count; i++)

--- a/server/src/elevation.c
+++ b/server/src/elevation.c
@@ -6,6 +6,8 @@
 */
 
 #include "../include/elevation.h"
+#include "../include/server.h"
+#include "../include/world.h"
 #include <stdio.h>
 
 void elevation_init_requirements(elevation_requirement_t *requirements)
@@ -20,26 +22,6 @@ void elevation_init_requirements(elevation_requirement_t *requirements)
     requirements[6] = (elevation_requirement_t) {6, {2, 2, 2, 2, 2, 1, 0}};
 }
 
-static bool can_start_incantation(tile_t *tile, int player_level,
-    const elevation_requirement_t *requirements)
-{
-    elevation_requirement_t req;
-
-    if (player_level < 1 || player_level > MAX_LEVEL) {
-        return false;
-    }
-    req = requirements[player_level - 1];
-    if (tile->player_count < req.required_players) {
-        return false;
-    }
-    for (int i = 0; i < NB_RESOURCE_TYPES; i++) {
-        if (tile->resources[i] < req.required_resources[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
 void start_incantation(tile_t *tile, int player_level,
     const elevation_requirement_t *requirements)
 {
@@ -50,26 +32,6 @@ void start_incantation(tile_t *tile, int player_level,
     for (size_t i = 0; i < tile->player_count; i++) {
         tile->players[i]->in_elevation = true;
     }
-}
-
-bool complete_incantation(tile_t *tile, int player_level,
-    const elevation_requirement_t *requirements)
-{
-    elevation_requirement_t req;
-
-    if (player_level < 1 || player_level > MAX_LEVEL) {
-        return false;
-    }
-    req = requirements[player_level - 1];
-    if (tile->player_count < req.required_players) {
-        return false;
-    }
-    for (int i = 0; i < NB_RESOURCE_TYPES; i++) {
-        if (tile->resources[i] < req.required_resources[i]) {
-            return false;
-        }
-    }
-    return true;
 }
 
 void apply_elevation(tile_t *tile, int player_level,
@@ -89,10 +51,29 @@ void apply_elevation(tile_t *tile, int player_level,
 
 void cancel_incantation(tile_t *tile, int player_level)
 {
-    if (player_level < 1 || player_level >= MAX_LEVEL) {
+    if (player_level < 1 || player_level >= MAX_LEVEL)
         return;
-    }
     for (size_t i = 0; i < tile->player_count; i++) {
         tile->players[i]->in_elevation = false;
     }
+}
+
+void complete_incantation_ritual(player_t *player, server_t *server)
+{
+    tile_t *current_tile;
+    client_t *player_client;
+    elevation_requirement_t requirements[MAX_LEVEL];
+
+    player_client = find_client_by_player(server, player);
+    if (!player_client)
+        return;
+    current_tile = get_tile(server->map, player->x, player->y);
+    if (!current_tile) {
+        zn_send_message(player_client->zn_sock, "ko");
+        cancel_incantation(current_tile, player->level);
+        return;
+    }
+    elevation_init_requirements(requirements);
+    check_and_send_elevation_status(server, player, current_tile,
+        requirements);
 }

--- a/server/src/elevation.c
+++ b/server/src/elevation.c
@@ -35,9 +35,9 @@ void start_incantation(tile_t *tile, int player_level,
 }
 
 void apply_elevation(tile_t *tile, int player_level,
-    const elevation_requirement_t *requirements)
+    const elevation_requirement_t *requirements, server_t *server)
 {
-    if (!complete_incantation(tile, player_level, requirements))
+    if (!complete_incantation(tile, player_level, requirements, server))
         return;
     for (size_t i = 0; i < tile->player_count; i++) {
         tile->players[i]->level++;

--- a/server/src/parsing.c
+++ b/server/src/parsing.c
@@ -112,6 +112,8 @@ static int init_server_memory(server_t *server)
         fprintf(stderr, "Memory allocation failed for server connection.\n");
         return 84;
     }
+    memset(server->connection, 0, sizeof(server_connection_t));
+    server->connection->server = server;
     server->args = malloc(sizeof(server_args_t));
     if (server->args == NULL) {
         fprintf(stderr, "Memory allocation failed for server arguments.\n");

--- a/server/src/parsing.c
+++ b/server/src/parsing.c
@@ -113,7 +113,6 @@ static int init_server_memory(server_t *server)
         return 84;
     }
     memset(server->connection, 0, sizeof(server_connection_t));
-    server->connection->server = server;
     server->args = malloc(sizeof(server_args_t));
     if (server->args == NULL) {
         fprintf(stderr, "Memory allocation failed for server arguments.\n");

--- a/server/src/send_state_msg_to_players.c
+++ b/server/src/send_state_msg_to_players.c
@@ -1,0 +1,32 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappynian
+** File description:
+** send_state_msg_to_players
+*/
+
+#include "../include/server.h"
+
+void send_ko_to_all_players(server_t *server, tile_t *current_tile, size_t i)
+{
+    client_t *fail_client;
+
+    if (current_tile->players[i] && current_tile->players[i]->in_elevation) {
+        fail_client = find_client_by_player(server, current_tile->players[i]);
+        if (fail_client) {
+            zn_send_message(fail_client->zn_sock, "ko");
+        }
+    }
+}
+
+void send_ok_to_all_players(server_t *server, tile_t *current_tile, size_t i)
+{
+    client_t *elevated_clt;
+
+    if (current_tile->players[i] && current_tile->players[i]->in_elevation) {
+        elevated_clt = find_client_by_player(server, current_tile->players[i]);
+        if (elevated_clt) {
+            zn_send_message(elevated_clt->zn_sock, "ok");
+        }
+    }
+}

--- a/server/src/send_state_msg_to_players.c
+++ b/server/src/send_state_msg_to_players.c
@@ -30,3 +30,16 @@ void send_ok_to_all_players(server_t *server, tile_t *current_tile, size_t i)
         }
     }
 }
+
+void send_stat_to_all_players(server_t *server, tile_t *current_tile,
+    size_t i, const char *stat_msg)
+{
+    client_t *elevated_clt;
+
+    if (current_tile->players[i] && current_tile->players[i]->in_elevation) {
+        elevated_clt = find_client_by_player(server, current_tile->players[i]);
+        if (elevated_clt) {
+            zn_send_message(elevated_clt->zn_sock, stat_msg);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces significant changes to the elevation mechanics in the server codebase, including new functionality for handling player elevation, resource checks, and communication with clients. It also includes updates to memory initialization and the addition of new source files to the build system.

### Elevation Mechanics Enhancements:
* **New elevation-related functions**: Added functions such as `can_start_incantation`, `check_and_send_elevation_status`, and `complete_incantation_ritual` to handle elevation logic, including resource validation and player communication. (`server/include/elevation.h` - [[1]](diffhunk://#diff-ee3c5c0ba20e917f6a5f7873b489bbea3d4385d55b311aff1267612eab2b5148L27-R38) `server/src/check_elevation.c` - [[2]](diffhunk://#diff-ae304ec6c5fa9026f1c0837bd86c19a258cb548466427668a8e8352870742c0dR1-R101)
* **Updates to elevation application**: Modified `apply_elevation` to include the `server` parameter for more robust elevation handling. (`server/src/elevation.c` - [server/src/elevation.cL55-R40](diffhunk://#diff-f1e5db2c0f272782e39f4922365a7ef0de12286b12a54020f9c69b7a5a583c4cL55-R40))
* **Integration with commands**: Updated the `cmd_incantation` function to handle elevation logic, including resource checks and elevation status updates. (`server/src/commands_actions.c` - [server/src/commands_actions.cL85-R104](diffhunk://#diff-dddeb60be2400adbfcbb7a31ca44a947beb751e2a974c7000de608aaee217abcL85-R104))

### Player Communication:
* **New messaging functions**: Added `send_ko_to_all_players`, `send_ok_to_all_players`, and `send_stat_to_all_players` to communicate elevation status to players. (`server/include/server.h` - [[1]](diffhunk://#diff-bb4f1c4db60a15d5b375dca5b18ffd637f79444af6b2ce7a482e93aa86d23399R117-R121) `server/src/send_state_msg_to_players.c` - [[2]](diffhunk://#diff-ea79f1d302ff09292db7e09307a17d57b63b2e8b79bdcaca581378dcb0c38debR1-R45)

### Build System Updates:
* **New source files**: Added `src/check_elevation.c` and `src/send_state_msg_to_players.c` to the build system (`server/Makefile` - [server/MakefileR50-R51](diffhunk://#diff-a075e17ae38ef8cf416cafd1cbb4a00c9334410a802856a3c2793ec85f857d4eR50-R51)).

### Memory Initialization:
* **Improved server memory initialization**: Added `memset` to initialize `server->connection` to zero during memory allocation. (`server/src/parsing.c` - [server/src/parsing.cR115](diffhunk://#diff-6c2bdcd63bb3b3e28205fa5f75e6df2a9dafb7a781486eeab6933f385924eaf1R115))