### PR TITLE
PR(Server) : server limits map handling

### DIFF
--- a/server/include/world.h
+++ b/server/include/world.h
@@ -30,6 +30,7 @@ typedef struct map_s {
 } map_t;
 
 map_t *create_map(size_t width, size_t height);
+void destroy_map(map_t *map);
 tile_t *get_tile(map_t *map, size_t x, size_t y);
 tile_t *get_tile_toroidal(map_t *map, int x, int y);
 void add_player_to_tile(tile_t *tile, player_t *player);

--- a/server/include/world.h
+++ b/server/include/world.h
@@ -30,7 +30,6 @@ typedef struct map_s {
 } map_t;
 
 map_t *create_map(size_t width, size_t height);
-void destroy_map(map_t *map);
 tile_t *get_tile(map_t *map, size_t x, size_t y);
 tile_t *get_tile_toroidal(map_t *map, int x, int y);
 void add_player_to_tile(tile_t *tile, player_t *player);

--- a/server/include/world.h
+++ b/server/include/world.h
@@ -32,10 +32,15 @@ typedef struct map_s {
 map_t *create_map(size_t width, size_t height);
 void destroy_map(map_t *map);
 tile_t *get_tile(map_t *map, size_t x, size_t y);
+tile_t *get_tile_toroidal(map_t *map, int x, int y);
 void add_player_to_tile(tile_t *tile, player_t *player);
 void remove_player_from_tile(tile_t *tile, player_t *player);
 bool take_resource_from_tile(tile_t *tile, int resource_type);
 bool set_resource_on_tile(tile_t *tile, int resource_type);
 int get_resource_type_from_name(const char *resource_name);
+void normalize_coordinates_toroidal(int *x, int *y, size_t width,
+    size_t height);
+int calculate_toroidal_distance(int x1, int y1, int x2, int y2,
+    size_t width, size_t height);
 
 #endif // WORLD_H

--- a/server/include/world.h
+++ b/server/include/world.h
@@ -40,7 +40,5 @@ bool set_resource_on_tile(tile_t *tile, int resource_type);
 int get_resource_type_from_name(const char *resource_name);
 void normalize_coordinates_toroidal(int *x, int *y, size_t width,
     size_t height);
-int calculate_toroidal_distance(int x1, int y1, int x2, int y2,
-    size_t width, size_t height);
 
 #endif // WORLD_H

--- a/server/src/eject_cmd.c
+++ b/server/src/eject_cmd.c
@@ -36,16 +36,16 @@ static void move_player_in_direction(player_t *player, int direction,
 
     switch (direction) {
         case NORTH:
-            new_y = (new_y - 1 + (int)map->height) % (int)map->height;
+            new_y--;
             break;
         case EAST:
-            new_x = (new_x + 1) % (int)map->width;
+            new_x++;
             break;
         case SOUTH:
-            new_y = (new_y + 1) % (int)map->height;
+            new_y++;
             break;
         case WEST:
-            new_x = (new_x - 1 + (int)map->width) % (int)map->width;
+            new_x--;
             break;
     }
     move_player(player, new_x, new_y, map);

--- a/server/src/eject_cmd.c
+++ b/server/src/eject_cmd.c
@@ -104,7 +104,7 @@ static void ejection(player_t *player, server_t *server,
         direction = get_dir(player, ejected);
         remove_player_from_tile(current_tile, ejected);
         move_player_in_direction(ejected, player->orientation, server->map);
-        new_tile = get_tile(server->map, ejected->x, ejected->y);
+        new_tile = get_tile_toroidal(server->map, ejected->x, ejected->y);
         if (new_tile)
             add_player_to_tile(new_tile, ejected);
         send_ppo(server, ejected);

--- a/server/src/handle_free.c
+++ b/server/src/handle_free.c
@@ -58,16 +58,16 @@ int handle_free(server_t *server)
 {
     if (server == NULL)
         return 0;
-    if (server->args != NULL) {
+    if (server->args != NULL)
         handle_free_args(server->args);
-    }
     if (server->connection != NULL) {
         free_clients_array(server->connection);
         free(server->connection);
     }
-    if (server->graphic_clients != NULL) {
+    if (server->graphic_clients != NULL)
         destroy_graphic_client_list(server->graphic_clients);
-    }
+    if (server->map != NULL)
+        destroy_map(server->map);
     free(server);
     return 0;
 }

--- a/server/src/look_vision_tiles.c
+++ b/server/src/look_vision_tiles.c
@@ -50,6 +50,8 @@ void add_other_tiles(char *result, player_t *player, map_t *map,
     for (int distance = 1; distance <= vision_range; distance++) {
         for (int offset = -distance; offset <= distance; offset++) {
             calculate_vision_coordinates(player, distance, offset, pos);
+            normalize_coordinates_toroidal(&pos[0], &pos[1], map->width,
+                map->height);
             strcat(result, ",");
             add_tile_contents(result, pos[0], pos[1], map);
         }

--- a/server/src/look_vision_tiles.c
+++ b/server/src/look_vision_tiles.c
@@ -50,8 +50,8 @@ void add_other_tiles(char *result, player_t *player, map_t *map,
     for (int distance = 1; distance <= vision_range; distance++) {
         for (int offset = -distance; offset <= distance; offset++) {
             calculate_vision_coordinates(player, distance, offset, pos);
-            pos[0] = (pos[0] + map->width) % map->width;
-            pos[1] = (pos[1] + map->height) % map->height;
+            normalize_coordinates_toroidal(&pos[0], &pos[1],
+                map->width, map->height);
             strcat(result, ",");
             add_tile_contents(result, pos[0], pos[1], map);
         }

--- a/server/src/look_vision_tiles.c
+++ b/server/src/look_vision_tiles.c
@@ -10,7 +10,7 @@
 
 void add_tile_contents(char *result, int x, int y, map_t *map)
 {
-    tile_t *tile = get_tile(map, x, y);
+    tile_t *tile = get_tile_toroidal(map, x, y);
 
     if (!tile)
         return;
@@ -50,8 +50,6 @@ void add_other_tiles(char *result, player_t *player, map_t *map,
     for (int distance = 1; distance <= vision_range; distance++) {
         for (int offset = -distance; offset <= distance; offset++) {
             calculate_vision_coordinates(player, distance, offset, pos);
-            normalize_coordinates_toroidal(&pos[0], &pos[1],
-                map->width, map->height);
             strcat(result, ",");
             add_tile_contents(result, pos[0], pos[1], map);
         }

--- a/server/src/player.c
+++ b/server/src/player.c
@@ -40,15 +40,20 @@ void destroy_player(player_t *player)
 
 void move_player(player_t *player, int x, int y, map_t *map)
 {
+    tile_t *old_tile = NULL;
+    tile_t *new_tile = NULL;
+
     if (player == NULL || map == NULL)
         return;
-    if (x < 0 || (size_t)x >= map->width || y < 0 ||
-        (size_t)y >= map->height) {
-        fprintf(stderr, "Move out of bounds: (%d, %d)\n", x, y);
-        return;
-    }
+    old_tile = get_tile(map, player->x, player->y);
+    if (old_tile)
+        remove_player_from_tile(old_tile, player);
+    normalize_coordinates_toroidal(&x, &y, map->width, map->height);
     player->x = x;
     player->y = y;
+    new_tile = get_tile(map, player->x, player->y);
+    if (new_tile)
+        add_player_to_tile(new_tile, player);
 }
 
 bool player_decrement_food(player_t *player)

--- a/server/src/player.c
+++ b/server/src/player.c
@@ -51,7 +51,7 @@ void move_player(player_t *player, int x, int y, map_t *map)
     normalize_coordinates_toroidal(&x, &y, map->width, map->height);
     player->x = x;
     player->y = y;
-    new_tile = get_tile(map, player->x, player->y);
+    new_tile = get_tile_toroidal(map, player->x, player->y);
     if (new_tile)
         add_player_to_tile(new_tile, player);
 }

--- a/server/src/world.c
+++ b/server/src/world.c
@@ -69,19 +69,6 @@ map_t *create_map(size_t width, size_t height)
     return map;
 }
 
-void destroy_map(map_t *map)
-{
-    if (!map)
-        return;
-    for (size_t y = 0; y < map->height; y++) {
-        for (size_t x = 0; x < map->width; x++)
-            free(map->tiles[y][x].players);
-        free(map->tiles[y]);
-    }
-    free(map->tiles);
-    free(map);
-}
-
 tile_t *get_tile(map_t *map, size_t x, size_t y)
 {
     if (!map || x >= map->width || y >= map->height) {

--- a/server/src/world.c
+++ b/server/src/world.c
@@ -120,24 +120,18 @@ void remove_player_from_tile(tile_t *tile, player_t *player)
     fprintf(stderr, "Player not found in tile\n");
 }
 
-static void normalize_coordinates(int *x, int *y, map_t *map)
+void destroy_map(map_t *map)
 {
-    if (!map || !x || !y)
+    if (!map) {
+        fprintf(stderr, "Invalid map\n");
         return;
-    while (*x < 0)
-        *x += map->width;
-    while (*y < 0)
-        *y += map->height;
-    while ((size_t)*x >= map->width)
-        *x -= map->width;
-    while ((size_t)*y >= map->height)
-        *y -= map->height;
-}
-
-tile_t *get_tile_toroidal(map_t *map, int x, int y)
-{
-    if (!map)
-        return NULL;
-    normalize_coordinates(&x, &y, map);
-    return &map->tiles[y][x];
+    }
+    for (size_t y = 0; y < map->height; y++) {
+        for (size_t x = 0; x < map->width; x++) {
+            free(map->tiles[y][x].players);
+        }
+        free(map->tiles[y]);
+    }
+    free(map->tiles);
+    free(map);
 }

--- a/server/src/world.c
+++ b/server/src/world.c
@@ -132,3 +132,25 @@ void remove_player_from_tile(tile_t *tile, player_t *player)
     }
     fprintf(stderr, "Player not found in tile\n");
 }
+
+static void normalize_coordinates(int *x, int *y, map_t *map)
+{
+    if (!map || !x || !y)
+        return;
+    while (*x < 0)
+        *x += map->width;
+    while (*y < 0)
+        *y += map->height;
+    while ((size_t)*x >= map->width)
+        *x -= map->width;
+    while ((size_t)*y >= map->height)
+        *y -= map->height;
+}
+
+tile_t *get_tile_toroidal(map_t *map, int x, int y)
+{
+    if (!map)
+        return NULL;
+    normalize_coordinates(&x, &y, map);
+    return &map->tiles[y][x];
+}

--- a/server/src/world_utils.c
+++ b/server/src/world_utils.c
@@ -41,7 +41,8 @@ bool set_resource_on_tile(tile_t *tile, int resource_type)
     return true;
 }
 
-void normalize_coordinates_toroidal(int *x, int *y, size_t width, size_t height)
+void normalize_coordinates_toroidal(int *x, int *y, size_t width,
+    size_t height)
 {
     if (!x || !y)
         return;

--- a/server/src/world_utils.c
+++ b/server/src/world_utils.c
@@ -55,3 +55,25 @@ void normalize_coordinates_toroidal(int *x, int *y, size_t width,
     while ((size_t)*y >= height)
         *y -= height;
 }
+
+static void normalize_coordinates(int *x, int *y, map_t *map)
+{
+    if (!map || !x || !y)
+        return;
+    while (*x < 0)
+        *x += map->width;
+    while (*y < 0)
+        *y += map->height;
+    while ((size_t)*x >= map->width)
+        *x -= map->width;
+    while ((size_t)*y >= map->height)
+        *y -= map->height;
+}
+
+tile_t *get_tile_toroidal(map_t *map, int x, int y)
+{
+    if (!map)
+        return NULL;
+    normalize_coordinates(&x, &y, map);
+    return &map->tiles[y][x];
+}

--- a/server/src/world_utils.c
+++ b/server/src/world_utils.c
@@ -41,8 +41,7 @@ bool set_resource_on_tile(tile_t *tile, int resource_type)
     return true;
 }
 
-void normalize_coordinates_toroidal(int *x, int *y, size_t width,
-    size_t height)
+void normalize_coordinates_toroidal(int *x, int *y, size_t width, size_t height)
 {
     if (!x || !y)
         return;
@@ -54,15 +53,4 @@ void normalize_coordinates_toroidal(int *x, int *y, size_t width,
         *x -= width;
     while ((size_t)*y >= height)
         *y -= height;
-}
-
-int calculate_toroidal_distance(int x1, int y1, int x2, int y2,
-    size_t width, size_t height)
-{
-    int dx = abs(x2 - x1);
-    int dy = abs(y2 - y1);
-
-    dx = (dx < (int)width - dx) ? dx : (int)width - dx;
-    dy = (dy < (int)height - dy) ? dy : (int)height - dy;
-    return dx + dy;
 }

--- a/server/src/world_utils.c
+++ b/server/src/world_utils.c
@@ -44,7 +44,7 @@ bool set_resource_on_tile(tile_t *tile, int resource_type)
 void normalize_coordinates_toroidal(int *x, int *y, size_t width,
     size_t height)
 {
-    if (!x || !y)
+    if (!x || !y || width == 0 || height == 0)
         return;
     while (*x < 0)
         *x += width;

--- a/server/src/world_utils.c
+++ b/server/src/world_utils.c
@@ -40,3 +40,29 @@ bool set_resource_on_tile(tile_t *tile, int resource_type)
     tile->resources[resource_type]++;
     return true;
 }
+
+void normalize_coordinates_toroidal(int *x, int *y, size_t width,
+    size_t height)
+{
+    if (!x || !y)
+        return;
+    while (*x < 0)
+        *x += width;
+    while (*y < 0)
+        *y += height;
+    while ((size_t)*x >= width)
+        *x -= width;
+    while ((size_t)*y >= height)
+        *y -= height;
+}
+
+int calculate_toroidal_distance(int x1, int y1, int x2, int y2,
+    size_t width, size_t height)
+{
+    int dx = abs(x2 - x1);
+    int dy = abs(y2 - y1);
+
+    dx = (dx < (int)width - dx) ? dx : (int)width - dx;
+    dy = (dy < (int)height - dy) ? dy : (int)height - dy;
+    return dx + dy;
+}


### PR DESCRIPTION
This pull request introduces changes to implement toroidal (wrap-around) behavior for map coordinates in the server's game logic. The most significant updates include adding new utility functions for coordinate normalization, replacing existing coordinate handling with toroidal logic, and removing the `destroy_map` function. These changes ensure consistent handling of out-of-bound coordinates and simplify memory management.

### Changes related to toroidal coordinate handling:

* [`server/include/world.h`](diffhunk://#diff-362d84ddb94b8fe1339e9df1193ac01a3760dabe81084827f99d6a5df393d353L33-R41): Added the `normalize_coordinates_toroidal` function for coordinate normalization and introduced `get_tile_toroidal` to retrieve tiles with toroidal behavior.
* [`server/src/world.c`](diffhunk://#diff-4fcd5a5305b88fb199496afaee4b7410e945c3980f3122807b88f6930bbbc3f0R122-R143): Implemented `get_tile_toroidal` and a helper function `normalize_coordinates` for toroidal coordinate normalization within the map.
* [`server/src/world_utils.c`](diffhunk://#diff-29bbccd201db6d04a20dc428396ecf6a4ce6201858298835621cac98d04f0204R43-R57): Added a standalone `normalize_coordinates_toroidal` function for general use in coordinate normalization.

### Updates to player movement and vision:

* [`server/src/eject_cmd.c`](diffhunk://#diff-1e94f787134d411e4db0a60ab0c3fab1b36314cfed1433d0c86b36f105d1e3e5L39-R48): Replaced `get_tile` with `get_tile_toroidal` and simplified directional movement logic by removing direct modulo operations, relying on toroidal normalization instead. [[1]](diffhunk://#diff-1e94f787134d411e4db0a60ab0c3fab1b36314cfed1433d0c86b36f105d1e3e5L39-R48) [[2]](diffhunk://#diff-1e94f787134d411e4db0a60ab0c3fab1b36314cfed1433d0c86b36f105d1e3e5L107-R107)
* [`server/src/look_vision_tiles.c`](diffhunk://#diff-cb10c3e848d491115f19be0adfd3094f236a79782257c6507cfe04916c106d56L13-R13): Updated vision-related functions to use `normalize_coordinates_toroidal` for consistent coordinate handling. [[1]](diffhunk://#diff-cb10c3e848d491115f19be0adfd3094f236a79782257c6507cfe04916c106d56L13-R13) [[2]](diffhunk://#diff-cb10c3e848d491115f19be0adfd3094f236a79782257c6507cfe04916c106d56L53-R54)
* [`server/src/player.c`](diffhunk://#diff-6cbd592f8e7429d633c8addb5120a70dd34510b84a9410a33301264ec39eb8fcR43-R56): Refactored `move_player` to use toroidal normalization and update player positions with `get_tile_toroidal`. Removed out-of-bound checks.

### Code cleanup and removal:

* [`server/src/world.c`](diffhunk://#diff-4fcd5a5305b88fb199496afaee4b7410e945c3980f3122807b88f6930bbbc3f0L72-L84): Removed the `destroy_map` function, simplifying memory management responsibilities.