### PR TITLE
feat(EntityManager): enhance stone creation by removing existing item…

### DIFF
--- a/gui/Core/EntityManager.cpp
+++ b/gui/Core/EntityManager.cpp
@@ -84,6 +84,13 @@ void EntityManager::createStones(int x, int y, int q0, int q1, int q2, int q3,
   for (auto &tile : tiles_) {
     if (tile->getName() == oss.str()) {
       position.set(x * 20.0f, 5.0f, y * 20.0f);
+      std::vector<std::string> items = {"food", "linemate", "deraumere", "sibur", "mendiane", "phiras", "thystame"};
+      for (const auto &item : items) {
+        size_t currentQuantity = tile->getInventory().getItemQuantity(item);
+        if (currentQuantity > 0) {
+          tile->getInventory().removeItem(item, currentQuantity);
+        }
+      }
       tile->getInventory().addItem("food", q0);
       tile->getInventory().addItem("linemate", q1);
       tile->getInventory().addItem("deraumere", q2);
@@ -94,6 +101,26 @@ void EntityManager::createStones(int x, int y, int q0, int q1, int q2, int q3,
       break;
     }
   }
+
+  float radius = 6.0f;
+  auto it = entity_.begin();
+  while (it != entity_.end()) {
+    if ((*it)->getName() != "Stone") {
+      ++it;
+      continue;
+    }
+    float distance =
+        std::sqrt(std::pow((*it)->getPosition().X - position.X, 2) +
+                  std::pow((*it)->getPosition().Z - position.Z, 2));
+    if (distance <= radius + 0.01f) {
+      if ((*it)->getNode())
+        (*it)->getNode()->remove();
+      it = entity_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
   std::vector<int> quantities = {q0, q1, q2, q3, q4, q5, q6};
   placeStoneEntities(position, quantities, stoneTextures, qB3D, stoneNames,
                      qScale);


### PR DESCRIPTION
This pull request introduces enhancements to the `createStones` method in `gui/Core/EntityManager.cpp` to improve inventory management and ensure proper handling of overlapping entities. The changes focus on clearing existing inventory items before adding new ones and removing overlapping stone entities within a defined radius.

### Inventory Management Improvements:
* [`gui/Core/EntityManager.cpp`](diffhunk://#diff-f1cf701eaf34dda4944e5a0ff891a8464f57b0908399a07aead4a2e851d4a7a0R87-R93): Added logic to clear existing inventory items (`food`, `linemate`, `deraumere`, `sibur`, `mendiane`, `phiras`, `thystame`) from tiles before adding new quantities to ensure accurate inventory updates.

### Entity Overlap Handling:
* [`gui/Core/EntityManager.cpp`](diffhunk://#diff-f1cf701eaf34dda4944e5a0ff891a8464f57b0908399a07aead4a2e851d4a7a0R104-R123): Implemented a mechanism to detect and remove overlapping stone entities within a radius of 6.0 units to prevent visual or logical conflicts in entity placement.…s and cleaning up nearby stones